### PR TITLE
Add optional support for LinearSolve.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,9 @@ authors = ["Knut Andreas Meyer and contributors"]
 version = "0.1.0"
 
 [deps]
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 
 [compat]
 julia = "1"
@@ -12,8 +14,9 @@ julia = "1"
 [extras]
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+LinearSolve = "7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "ForwardDiff", "LinearAlgebra", "SparseArrays"]
+test = ["Test", "ForwardDiff", "LinearAlgebra", "SparseArrays", "LinearSolve"]

--- a/docs/src/linearsolvers.md
+++ b/docs/src/linearsolvers.md
@@ -11,3 +11,9 @@ FESolvers.solve_linear!
 ```@docs
 BackslashSolver
 ```
+
+### `LinearSolve.jl`
+The linear solvers in [`LinearSolve.jl`](https://github.com/SciML/LinearSolve.jl) are available 
+if the `LinearSolve.jl` package is available (implemented via [`Requires.jl`](https://github.com/JuliaPackaging/Requires.jl)).
+This also includes their default solver that is supplied setting the linear solver to `nothing`. 
+Please see `LinearSolve.jl`'s [documentation](https://docs.sciml.ai/LinearSolve/stable/) for their different solvers. 

--- a/src/FESolvers.jl
+++ b/src/FESolvers.jl
@@ -1,5 +1,6 @@
 module FESolvers
 import LinearAlgebra
+using Requires
 export solve_problem!
 
 export QuasiStaticSolver
@@ -31,5 +32,15 @@ For details on the functions that should be defined for `problem`,
 see [User problem](@ref)
 """
 function solve_problem! end
+
+function __init__()
+    @require(
+        LinearSolve="7ed4a6bd-45f5-4d41-b270-4a48e9bafcae",
+        (using .LinearSolve;
+        function solve_linear!(Δx, K, r, alg::Union{LinearSolve.SciMLLinearSolveAlgorithm,Nothing})
+            map!(-, Δx, solve(LinearProblem(K, copy!(Δx,r)), alg; alias_b=false).u)
+        end)
+    )
+end
 
 end

--- a/test/test_linearsolvers.jl
+++ b/test/test_linearsolvers.jl
@@ -1,7 +1,8 @@
 using SparseArrays, LinearAlgebra
 @testset "linearsolvers" begin
+    using LinearSolve
     for K in (rand(10,10)+10I, sprand(10,10,0.2)+10I)
-        for linsolver in (BackslashSolver(), )
+        for linsolver in (BackslashSolver(), nothing, (isa(K,Matrix) ? SimpleLUFactorization() : KLUFactorization()))
             @testset "$(typeof(K)), $(typeof(linsolver))" begin
                 r =  rand(size(K,1))
                 Δx = similar(r)


### PR DESCRIPTION
This PR makes it possible to use the linear solvers from `LinearSolve.jl` if the user is `using LinearSolve`,
but does not make `LinearSolve.jl` a dependency. 