### PR TITLE
Δa and iteration count in convergence criterion + make calculate_update! mutating

### DIFF
--- a/docs/src/literate/plasticity.jl
+++ b/docs/src/literate/plasticity.jl
@@ -161,7 +161,7 @@ end;
 
 # In this example, we use the standard convergence criterion that the norm of the free 
 # degrees of freedom is less than the iteration tolerance. 
-FESolvers.calculate_convergence_measure(p::PlasticityProblem) = norm(FESolvers.getresidual(p)[free_dofs(p.def.dbcs)]);
+FESolvers.calculate_convergence_measure(p::PlasticityProblem, args...) = norm(FESolvers.getresidual(p)[free_dofs(p.def.dbcs)]);
 
 # After convergence, we need to update the state variables. 
 function FESolvers.handle_converged!(p::PlasticityProblem)

--- a/docs/src/nlsolvers.md
+++ b/docs/src/nlsolvers.md
@@ -7,7 +7,7 @@ FESolvers.solve_nonlinear!
 
 It can do so, by supporting the following functions
 ```@docs
-FESolvers.calculate_update
+FESolvers.calculate_update!
 FESolvers.getmaxiter
 FESolvers.gettolerance
 ```

--- a/src/nlsolvers.jl
+++ b/src/nlsolvers.jl
@@ -7,12 +7,12 @@ by using the nonlinear solver: `nlsolver`.
 function solve_nonlinear! end
 
 """
-    function calculate_update(problem, nlsolver, iter)
+    function calculate_update!(Δx, problem, nlsolver, iter)
 
 According to the nonlinear solver, `nlsolver`, at iteration `iter`,
 calculate the update, `Δx` to the unknowns `x`.
 """
-function calculate_update end
+function calculate_update! end
 
 """
     getmaxiter(nlsolver)
@@ -126,17 +126,17 @@ function solve_nonlinear!(nlsolver, problem)
     maxiter = getmaxiter(nlsolver)
     reset_state!(nlsolver)
     update_problem!(problem)
+    Δa = zero(getunknowns(problem))
     for iter in 1:maxiter
-        check_convergence_criteria(problem, nlsolver) && return true
-        Δa = calculate_update(problem, nlsolver, iter)
+        check_convergence_criteria(problem, nlsolver, Δa, iter) && return true
+        calculate_update!(Δa, problem, nlsolver, iter)
         update_problem!(problem, Δa)
     end
-    check_convergence_criteria(problem, nlsolver) && return true
+    check_convergence_criteria(problem, nlsolver, Δa, maxiter+1) && return true
     return false
 end
 
-function calculate_update(problem, nlsolver::Union{SteepestDescent,NewtonSolver}, iter)
-    Δa = similar(getunknowns(problem))  # TODO: Should have a solvercache for these
+function calculate_update!(Δa, problem, nlsolver::Union{SteepestDescent,NewtonSolver}, iter)
     r = getresidual(problem)
     K = getsystemmatrix(problem,nlsolver)
     solve_linear!(Δa, K, r, nlsolver.linsolver)

--- a/src/userfunctions.jl
+++ b/src/userfunctions.jl
@@ -80,12 +80,13 @@ function update_problem! end
 
 
 """
-    calculate_convergence_measure(problem) -> AbstractFloat
+    calculate_convergence_measure(problem, Δa, iter) -> AbstractFloat
 
 Calculate a value to be compared with the tolerance of the nonlinear solver. 
 A standard case when using [Ferrite.jl](https://github.com/Ferrite-FEM/Ferrite.jl)
-is `norm(getresidual(problem)[Ferrite.free_dofs(dbcs)])` 
-where `dbcs::Ferrite.ConstraintHandler`.
+is `norm(getresidual(problem)[Ferrite.free_dofs(ch)])` 
+where `ch::Ferrite.ConstraintHandler`. `Δa` is the update of the unknowns from 
+the previous iteration. Note that `iter=1` implies `Δa=0`
 
 The advanced API alternative is [`check_convergence_criteria`](@ref)
 
@@ -93,14 +94,14 @@ The advanced API alternative is [`check_convergence_criteria`](@ref)
 function calculate_convergence_measure end
 
 """
-    check_convergence_criteria(problem, nlsolver) -> Bool
+    check_convergence_criteria(problem, nlsolver, Δa, iter) -> Bool
 
 Check if `problem` has converged and update the state 
 of `nlsolver` wrt. number of iterations and a convergence
 measure if applicable.
 """
-function check_convergence_criteria(problem, nlsolver)
-    r = calculate_convergence_measure(problem)
+function check_convergence_criteria(problem, nlsolver, Δa, iter)
+    r = calculate_convergence_measure(problem, Δa, iter)
     update_state!(nlsolver, r)
     return r < gettolerance(nlsolver)
 end

--- a/test/TestNLSolver.jl
+++ b/test/TestNLSolver.jl
@@ -7,8 +7,8 @@ end
 FESolvers.getmaxiter(s::TestNLSolver) = s.maxiter
 FESolvers.gettolerance(s::TestNLSolver) = s.tolerance
 
-function FESolvers.calculate_update(problem, nlsolver::TestNLSolver, iter)
-    Δa = -FESolvers.getjacobian(problem)\FESolvers.getresidual(problem)
+function FESolvers.calculate_update!(Δa, problem, nlsolver::TestNLSolver, iter)
+    Δa .= -FESolvers.getjacobian(problem)\FESolvers.getresidual(problem)
     iter == 1 && FESolvers.linesearch!(Δa, problem, nlsolver.ls)
     return Δa
 end

--- a/test/testproblem.jl
+++ b/test/testproblem.jl
@@ -43,7 +43,7 @@ function FESolvers.update_problem!(p::TestProblem, Δx=nothing)
     p.drdx .= ForwardDiff.jacobian(x_->residual(x_, p.f), p.x)
 end
 
-FESolvers.calculate_convergence_measure(p::TestProblem) = norm(p.r)
+FESolvers.calculate_convergence_measure(p::TestProblem, args...) = norm(p.r)
 FESolvers.handle_converged!(p::TestProblem) = push!(p.conv, true)
 function FESolvers.postprocess!(p::TestProblem, step)
     push!(p.xv, copy(p.x))
@@ -74,5 +74,5 @@ function FESolvers.update_problem!(p::Rosenbrock, Δx=nothing)
     p.r .= dfdx
     p.drdx .= d²fdxdx
 end
-FESolvers.calculate_convergence_measure(p::Rosenbrock) = norm(p.r)
+FESolvers.calculate_convergence_measure(p::Rosenbrock, args...) = norm(p.r)
 


### PR DESCRIPTION
Adds Δa and iteration number to `check_convergence_criterion` and `calculate_convergence_measure`.
Additionally (to support this and because good in general), makes `calculate_update!(Δa, problem, nlsolver, iter)` mutating