### PR TITLE
LinearProblemSolver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.vscode
 /Manifest.toml
 /docs/build/
+/docs/src/examples/

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -1,6 +1,6 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.8.1"
+julia_version = "1.8.3"
 manifest_format = "2.0"
 project_hash = "aedb8c1b021f4165529ffe5c59e70ce3cc471edf"
 
@@ -166,7 +166,7 @@ uuid = "2e619515-83b5-522b-bb60-26c02a35a201"
 version = "2.4.8+0"
 
 [[deps.FESolvers]]
-deps = ["LinearAlgebra"]
+deps = ["ForwardDiff", "LinearAlgebra", "Requires"]
 path = ".."
 uuid = "79314e9b-2e6f-4d6d-a72d-515aa2604984"
 version = "0.1.0"
@@ -178,10 +178,10 @@ uuid = "c87230d0-a227-11e9-1b43-d7ebe4e7570a"
 version = "0.4.1"
 
 [[deps.FFMPEG_jll]]
-deps = ["Artifacts", "Bzip2_jll", "FreeType2_jll", "FriBidi_jll", "JLLWrappers", "LAME_jll", "Libdl", "Ogg_jll", "OpenSSL_jll", "Opus_jll", "Pkg", "Zlib_jll", "libaom_jll", "libass_jll", "libfdk_aac_jll", "libvorbis_jll", "x264_jll", "x265_jll"]
-git-tree-sha1 = "ccd479984c7838684b3ac204b716c89955c76623"
+deps = ["Artifacts", "Bzip2_jll", "FreeType2_jll", "FriBidi_jll", "JLLWrappers", "LAME_jll", "Libdl", "Ogg_jll", "OpenSSL_jll", "Opus_jll", "PCRE2_jll", "Pkg", "Zlib_jll", "libaom_jll", "libass_jll", "libfdk_aac_jll", "libvorbis_jll", "x264_jll", "x265_jll"]
+git-tree-sha1 = "74faea50c1d007c85837327f6775bea60b5492dd"
 uuid = "b22a6f82-2f65-5046-a5b2-351ab43fb4e5"
-version = "4.4.2+0"
+version = "4.4.2+2"
 
 [[deps.Ferrite]]
 deps = ["EnumX", "LinearAlgebra", "NearestNeighbors", "Reexport", "SparseArrays", "Tensors", "WriteVTK"]
@@ -218,9 +218,9 @@ version = "0.4.2"
 
 [[deps.ForwardDiff]]
 deps = ["CommonSubexpressions", "DiffResults", "DiffRules", "LinearAlgebra", "LogExpFunctions", "NaNMath", "Preferences", "Printf", "Random", "SpecialFunctions", "StaticArrays"]
-git-tree-sha1 = "187198a4ed8ccd7b5d99c41b69c679269ea2b2d4"
+git-tree-sha1 = "a69dd6db8a809f78846ff259298678f0d6212180"
 uuid = "f6369f11-7733-5829-9624-2563aa707210"
-version = "0.10.32"
+version = "0.10.34"
 
 [[deps.FreeType2_jll]]
 deps = ["Artifacts", "Bzip2_jll", "JLLWrappers", "Libdl", "Pkg", "Zlib_jll"]
@@ -414,9 +414,9 @@ version = "1.42.0+0"
 
 [[deps.Libiconv_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "42b62845d70a619f063a7da093d995ec8e15e778"
+git-tree-sha1 = "c7cb1f5d892775ba13767a87c7ada0b980ea0a71"
 uuid = "94ce4f54-9a6c-5748-9c1c-f9c7231a4531"
-version = "1.16.1+1"
+version = "1.16.1+2"
 
 [[deps.Libmount_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
@@ -567,6 +567,11 @@ git-tree-sha1 = "85f8e6578bf1f9ee0d11e7bb1b1456435479d47c"
 uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 version = "1.4.1"
 
+[[deps.PCRE2_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "efcefdf7-47ab-520b-bdef-62a2eaa19f15"
+version = "10.40.0+0"
+
 [[deps.PCRE_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
 git-tree-sha1 = "b2a7af664e098055a7529ad1a900ded962bca488"
@@ -625,9 +630,9 @@ uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [[deps.Qt5Base_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "Fontconfig_jll", "Glib_jll", "JLLWrappers", "Libdl", "Libglvnd_jll", "OpenSSL_jll", "Pkg", "Xorg_libXext_jll", "Xorg_libxcb_jll", "Xorg_xcb_util_image_jll", "Xorg_xcb_util_keysyms_jll", "Xorg_xcb_util_renderutil_jll", "Xorg_xcb_util_wm_jll", "Zlib_jll", "xkbcommon_jll"]
-git-tree-sha1 = "c6c0f690d0cc7caddb74cef7aa847b824a16b256"
+git-tree-sha1 = "0c03844e2231e12fda4d0086fd7cbe4098ee8dc5"
 uuid = "ea2cea3b-5b76-57ae-a6ef-0a8af62496e1"
-version = "5.15.3+1"
+version = "5.15.3+2"
 
 [[deps.REPL]]
 deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
@@ -753,7 +758,7 @@ version = "1.0.0"
 [[deps.Tar]]
 deps = ["ArgTools", "SHA"]
 uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
-version = "1.10.0"
+version = "1.10.1"
 
 [[deps.TensorCore]]
 deps = ["LinearAlgebra"]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -4,7 +4,7 @@ using Documenter
 const is_ci = get(ENV, "CI", "false") == "true"
 
 include("generate.jl")
-examples = ["plasticity.jl",]
+examples = ["plasticity.jl", "transient_heat.jl"]
 GENERATEDEXAMPLES = [joinpath("examples", replace(f, ".jl"=>".md")) for f in examples]
 
 build_examples(examples)

--- a/docs/src/literate/plasticity.jl
+++ b/docs/src/literate/plasticity.jl
@@ -143,10 +143,10 @@ function FESolvers.update_to_next_step!(p::PlasticityProblem, time)
 end;
 
 # Next, we define the updating of the problem given a new guess to the solution. 
-# Note that we use `Δu=nothing` for the case it is not given, to signal no change.
+# Note that we use `Δu::Nothing` for the case it is not given, to signal no change.
 # This version is called directly after update_to_next_step! before entering 
 # the nonlinear iterations. 
-function FESolvers.update_problem!(p::PlasticityProblem, Δu=nothing)
+function FESolvers.update_problem!(p::PlasticityProblem, Δu; kwargs...)
     buf = p.buf 
     def = p.def
     if !isnothing(Δu)

--- a/docs/src/literate/transient_heat.jl
+++ b/docs/src/literate/transient_heat.jl
@@ -39,7 +39,7 @@
 #md # The full program, without comments, can be found in the next [section](@ref heat_equation-plain-program).
 #
 # First we load Ferrite, and some other packages we need.
-using Ferrite, SparseArrays
+using Ferrite, SparseArrays, FESolvers
 # 
 # Then, we define our problem structs. At the end, we will define a nice constructor for this. 
 struct TransientHeat{DEF,BUF,POST}

--- a/docs/src/literate/transient_heat.jl
+++ b/docs/src/literate/transient_heat.jl
@@ -1,0 +1,222 @@
+# # Linear Time Dependent Problem
+# This example is taken from 
+# [`Ferrite.jl`'s transient heat flow](https://ferrite-fem.github.io/Ferrite.jl/stable/examples/transient_heat_equation/).
+# We modify the material parameters to get more time-dependent behavior. 
+# 
+# Currently, only Quasi-static problems are supported by FESolvers. Therefore, we reformulate the linear system compared 
+# to remove the mass matrices. We have the same time-discretized weak form:
+# ```math
+# \int_{\Omega} v\, u_{n+1}\ \mathrm{d}\Omega + \Delta t\int_{\Omega} k \nabla v \cdot \nabla u_{n+1} \ \mathrm{d}\Omega = \Delta t\int_{\Omega} v f \ \mathrm{d}\Omega + \int_{\Omega} v \, u_{n} \ \mathrm{d}\Omega.
+# ```
+# We then define the linear residual, ``r(u_{n+1})``, as 
+# ```math
+# r(u_{n+1}) = f_\mathrm{int}(u_{n+1}) - f_\mathrm{ext}(u_{n}) \\
+# f_\mathrm{int}(u_{n+1}) = \int_{\Omega} v\, u_{n+1}\ \mathrm{d}\Omega + \Delta t\int_{\Omega} k \nabla v \cdot \nabla u_{n+1} \ \mathrm{d}\Omega  \\
+# f_\mathrm{ext}(u_{n}) = \Delta t\int_{\Omega} v f \ \mathrm{d}\Omega + \int_{\Omega} v \, u_{n} \ \mathrm{d}\Omega. \\
+# ```
+# giving the discrete operators
+# ```math
+# r_i(\mathbf{u}_{n+1}) = K_{ij} [\mathbf{u}_{n+1}]_j - [\mathbf{f}_\mathrm{ext}(u_{n})]_i
+# ```
+# upon introduction of the function approximation, ``u(\mathbf{x}) \approx N_i(\mathbf{x}) u_i``, and the test approximation, 
+# ``v(\mathbf{x}) \approx \delta N_i(\mathbf{x}) v_i``
+# where 
+# ```math
+# K_{ij} = \int_{\Omega} \delta N_i(\mathbf{x})\, N_j(\mathbf{x}) \ \mathrm{d}\Omega + \Delta t\int_{\Omega} k \nabla \delta N_i(\mathbf{x}) \cdot \nabla N_j(\mathbf{x}) \ \mathrm{d}\Omega  \\
+# \left[\mathbf{f}_\mathrm{ext}(u_{n})\right]_i = \Delta t\int_{\Omega} \delta N_i(\mathbf{x}) f \ \mathrm{d}\Omega + \int_{\Omega} \delta N_i(\mathbf{x}) \, u_{n}(\mathbf{x}) \ \mathrm{d}\Omega.
+# ```
+# and the residual expression can be simplified to 
+# ```math
+# r_i = 
+# \int_{\Omega} \delta N_i(\mathbf{x})\, \left[u(\mathbf{x})-u_{n}(\mathbf{x})\right] \ \mathrm{d}\Omega 
+# + \Delta t\int_{\Omega} k \nabla \delta N_i(\mathbf{x}) \cdot \nabla u(\mathbf{x}) \ \mathrm{d}\Omega 
+# - \Delta t\int_{\Omega} \delta N_i(\mathbf{x}) f \ \mathrm{d}\Omega
+# ```
+# 
+# ## Commented Program
+#
+# Now we solve the problem by using Ferrite and FESolvers. 
+#md # The full program, without comments, can be found in the next [section](@ref heat_equation-plain-program).
+#
+# First we load Ferrite, and some other packages we need.
+using Ferrite, SparseArrays
+# 
+# Then, we define our problem structs. At the end, we will define a nice constructor for this. 
+struct TransientHeat{DEF,BUF,POST}
+    def::DEF    # Problem definition
+    buf::BUF    # Buffers for storing values 
+    post::POST  # Struct to save simulation data in each step 
+end
+
+struct ProblemDefinition{DH,CH,CV}
+    dh::DH
+    ch::CH
+    cv::CV 
+end
+
+function ProblemDefinition()
+    ## **Grid**
+    grid = generate_grid(Quadrilateral, (100, 100));
+
+    ## **Cell values**
+    dim = 2
+    ip = Lagrange{dim, RefCube, 1}()
+    qr = QuadratureRule{dim, RefCube}(2)
+    cellvalues = CellScalarValues(qr, ip);
+
+    ## **Degrees of freedom**
+    ## After this, we can define the `DofHandler` and distribute the DOFs of the problem.
+    dh = DofHandler(grid)
+    push!(dh, :u, 1)
+    close!(dh);
+
+    ## **Boundary conditions**
+    ## In order to define the time dependent problem, we need some end time `T` and something that describes
+    ## the linearly increasing Dirichlet boundary condition on $\partial \Omega_2$.
+    max_temp = 100
+    t_rise = 100
+    ch = ConstraintHandler(dh);
+
+    ## Here, we define the boundary condition related to $\partial \Omega_1$.
+    ∂Ω₁ = union(getfaceset.((grid,), ["left", "right"])...)
+    dbc = Dirichlet(:u, ∂Ω₁, (x, t) -> 0)
+    add!(ch, dbc);
+    ## While the next code block corresponds to the linearly increasing temperature description on $\partial \Omega_2$
+    ## until `t=t_rise`, and then keep constant
+    ∂Ω₂ = union(getfaceset.((grid,), ["top", "bottom"])...)
+    dbc = Dirichlet(:u, ∂Ω₂, (x, t) -> max_temp * clamp(t / t_rise, 0, 1))
+    add!(ch, dbc)
+    close!(ch)
+    return ProblemDefinition(dh, ch, cellvalues)
+end;
+
+# We then define a problem buffer, that can be created based on the `ProblemDefinition`
+struct ProblemBuffer{KT,T}
+    K::KT 
+    r::Vector{T}
+    u::Vector{T}
+    uold::Vector{T}
+    times::Vector{T}    # [t_old, t_current]
+end
+function ProblemBuffer(def::ProblemDefinition)
+    dh = def.dh
+    K = create_sparsity_pattern(dh)
+    r = zeros(ndofs(dh))
+    u = zeros(ndofs(dh))
+    uold = zeros(ndofs(dh))
+    times = zeros(2)
+    return ProblemBuffer(K, r, u, uold, times)
+end;
+
+# We also need functions to assemble the stiffness and residual vectors 
+function doassemble!(K::SparseMatrixCSC, r::Vector, cellvalues::CellScalarValues, dh::DofHandler, u, uold, Δt)
+    n_basefuncs = getnbasefunctions(cellvalues)
+    Ke = zeros(n_basefuncs, n_basefuncs)
+    re = zeros(n_basefuncs)
+    ue = zeros(n_basefuncs)
+    ue_old = zeros(n_basefuncs)
+    assembler = start_assemble(K, r)
+    for cell in CellIterator(dh)
+        fill!(Ke, 0)
+        fill!(re, 0)
+        ue .= u[celldofs(cell)]
+        ue_old .= uold[celldofs(cell)]
+        reinit!(cellvalues, cell)
+        element_routine!(Ke, re, cellvalues, ue, ue_old, Δt)
+        assemble!(assembler, celldofs(cell), re, Ke)
+    end
+end
+
+function element_routine!(Ke, re, cellvalues, ue, ue_old, Δt, k=1.0e-3, f=0.5)
+    n_basefuncs = getnbasefunctions(cellvalues)
+    for q_point in 1:getnquadpoints(cellvalues)
+        dΩ = getdetJdV(cellvalues, q_point)
+        u = function_value(cellvalues, q_point, ue)
+        uold = function_value(cellvalues, q_point, ue_old)
+        ∇u = function_gradient(cellvalues, q_point, ue)
+        for i in 1:n_basefuncs
+            δN = shape_value(cellvalues, q_point, i)
+            ∇δN = shape_gradient(cellvalues, q_point, i)
+            re[i] += (δN * (u - uold - Δt * f) + Δt * k * ∇δN ⋅ ∇u) * dΩ
+            for j in 1:n_basefuncs
+                N = shape_value(cellvalues, q_point, j)
+                ∇N = shape_gradient(cellvalues, q_point, j)
+                Ke[i, j] += (δN*N + Δt * k * (∇δN ⋅ ∇N)) * dΩ
+            end
+        end
+    end
+end;
+
+# We now define all the required methods for solving this system with using the `LinearProblemSolver`
+FESolvers.getunknowns(p::TransientHeat) = p.buf.u
+FESolvers.getresidual(p::TransientHeat) = p.buf.r 
+FESolvers.getjacobian(p::TransientHeat) = p.buf.K 
+
+function FESolvers.update_to_next_step!(p::TransientHeat, time)
+    p.buf.times[2] = time       # Update current time 
+    update!(p.def.ch, time)     # Update Dirichlet boundary conditions
+    apply!(FESolvers.getunknowns(p), p.def.ch)
+end
+
+function FESolvers.update_problem!(p::TransientHeat, Δu; update_jacobian, update_residual)
+    if !isnothing(Δu)
+        apply_zero!(Δu, p.def.ch)
+        p.buf.u .+= Δu
+    end
+    ## Since the problem is linear, we can save some computations by only updating once per time step 
+    ## and not after updating the temperatures to check that it has converged. 
+    if update_jacobian || update_residual
+        Δt = p.buf.times[2]-p.buf.times[1]
+        doassemble!(p.buf.K, p.buf.r, p.def.cv, p.def.dh, FESolvers.getunknowns(p), p.buf.uold, Δt)
+        apply_zero!(FESolvers.getjacobian(p), FESolvers.getresidual(p), p.def.ch)
+    end
+    return nothing
+end
+
+function FESolvers.handle_converged!(p::TransientHeat)
+    copy!(p.buf.uold, FESolvers.getunknowns(p)) # Set old temperature to current 
+    p.buf.times[1] = p.buf.times[2]             # Set old time to current 
+end;
+
+# We are now ready to solve the system, but to save some data we must define some postprocessing tasks
+# In this example, we only save things to file 
+struct PostProcessing{PVD}
+    pvd::PVD
+end
+PostProcessing() = PostProcessing(paraview_collection("transient-heat.pvd"));
+
+function FESolvers.postprocess!(p::TransientHeat, step)
+    vtk_grid("transient-heat-$step", p.def.dh) do vtk
+        vtk_point_data(vtk, p.def.dh, p.buf.u)
+        vtk_save(vtk)
+        p.post.pvd[step] = vtk
+    end
+end;
+
+# At the end of the simulation, we want to finish all IO operations. 
+# We can then define the function `close_problem` which will be called 
+# even in the case that an error is thrown during the simulation
+function FESolvers.close_problem(p::TransientHeat)
+    vtk_save(p.post.pvd)
+end;
+
+# We then define a nice constructor for `TransientHeat` and can solve the problem,
+TransientHeat(def) = TransientHeat(def, ProblemBuffer(def), PostProcessing());
+
+# And now we create the problem type, and define the QuasiStaticSolver with 
+# the LinearProblemSolver as well as fixed time steps 
+problem = TransientHeat(ProblemDefinition())
+solver = QuasiStaticSolver(;nlsolver=LinearProblemSolver(), timestepper=FixedTimeStepper(collect(0.0:1.0:200)));
+
+# Finally, we can solve the problem
+solve_problem!(solver, problem);
+
+#md # ## [Plain program](@id transient_heat_equation-plain-program)
+#md #
+#md # Here follows a version of the program without any comments.
+#md # The file is also available here:
+#md # [`transient_heat_equation.jl`](transient_heat_equation.jl).
+#md #
+#md # ```julia
+#md # @__CODE__
+#md # ```

--- a/docs/src/nlsolvers.md
+++ b/docs/src/nlsolvers.md
@@ -20,6 +20,7 @@ FESolvers.reset_state!
 ## Implemented Solvers
 
 ```@docs
+LinearProblemSolver
 NewtonSolver
 SteepestDescent
 ```

--- a/src/FESolvers.jl
+++ b/src/FESolvers.jl
@@ -4,6 +4,7 @@ using Requires
 export solve_problem!
 
 export QuasiStaticSolver
+export LinearProblemSolver
 export NewtonSolver, SteepestDescent
 export NoLineSearch, ArmijoGoldstein
 export BackslashSolver

--- a/src/QuasiStaticSolver.jl
+++ b/src/QuasiStaticSolver.jl
@@ -42,8 +42,8 @@ function _solve_problem!(solver::QuasiStaticSolver, problem)
         converged = solve_nonlinear!(solver.nlsolver, problem)
         if converged
             copy!(xold, getunknowns(problem))
-            handle_converged!(problem)
             postprocess!(problem, step, solver)
+            handle_converged!(problem)
         else
             # Reset unknowns if it didn't converge to 
             setunknowns!(problem, xold)

--- a/src/nlsolvers.jl
+++ b/src/nlsolvers.jl
@@ -147,6 +147,12 @@ end
 """
     LinearProblemSolver(;linsolver=BackslashSolver())
 
+This is a special type of "Nonlinear solver", which actually only solves linear problems, 
+but allows all other features (i.e. time stepping and postprocessing) of the `FESolvers` 
+package to be used. In particular, it allows you to maintain all other parts of your problem 
+exactly the same as for a nonlinear problem, but it is possible to get better performance as 
+it is, in principle, not necessary to assemble twice in each time step. 
+
 This solver is specialized for linear problems of the form
 ```math
 \\boldsymbol{r}(\\boldsymbol{x}(t),t)=\\boldsymbol{K}(t) \\boldsymbol{x}(t) - \\boldsymbol{f}(t)

--- a/src/nlsolvers.jl
+++ b/src/nlsolvers.jl
@@ -125,12 +125,12 @@ end
 function solve_nonlinear!(nlsolver, problem)
     maxiter = getmaxiter(nlsolver)
     reset_state!(nlsolver)
-    update_problem!(problem)
+    update_problem!(problem, nothing; update_residual=true, update_jacobian=true)
     Δa = zero(getunknowns(problem))
     for iter in 1:maxiter
         check_convergence_criteria(problem, nlsolver, Δa, iter) && return true
         calculate_update!(Δa, problem, nlsolver, iter)
-        update_problem!(problem, Δa)
+        update_problem!(problem, Δa; update_residual=true, update_jacobian=true)
     end
     check_convergence_criteria(problem, nlsolver, Δa, maxiter+1) && return true
     return false
@@ -178,11 +178,11 @@ LinearProblemSolver(;linsolver=BackslashSolver()) = LinearProblemSolver(linsolve
 getsystemmatrix(problem, ::LinearProblemSolver) = getjacobian(problem)
 
 function solve_nonlinear!(nlsolver::LinearProblemSolver, problem)
-    update_problem!(problem)
+    update_problem!(problem, nothing; update_residual=true, update_jacobian=true)
     r = getresidual(problem)
     K = getsystemmatrix(problem,nlsolver)
     Δa = similar(getunknowns(problem))
     solve_linear!(Δa, K, r, nlsolver.linsolver)
-    update_problem!(problem, Δa)
+    update_problem!(problem, Δa; update_residual=false, update_jacobian=false)
     return true # Assume always converged
 end

--- a/src/nlsolvers.jl
+++ b/src/nlsolvers.jl
@@ -162,9 +162,9 @@ It expects that ``\\boldsymbol{x}(t)`` and ``\\boldsymbol{r}(t)`` have been upda
 ``\\boldsymbol{x}_\\mathrm{bc}`` and ``\\boldsymbol{r}_\\mathrm{bc}=\\boldsymbol{K}(t)\\boldsymbol{x}_\\mathrm{bc}-\\boldsymbol{f}(t)``,
 such that 
 ```math
-\\boldsymbol{x}(t) = \\boldsymbol{K}^{-1}(t)\\boldsymbol{r}_\\mathrm{bc} -\\boldsymbol{x}_\\mathrm{bc}
-= \\boldsymbol{K}^{-1}(t)\\left[\\boldsymbol{K}(t)\\boldsymbol{x}_\\mathrm{bc}-\\boldsymbol{f}(t)\\right] -\\boldsymbol{x}_\\mathrm{bc}
-= -\\boldsymbol{K}^{-1}(t)\\boldsymbol{f}(t)
+\\boldsymbol{x}(t) = \\boldsymbol{x}_\\mathrm{bc} - \\boldsymbol{K}^{-1}(t)\\boldsymbol{r}_\\mathrm{bc}
+= \\boldsymbol{x}_\\mathrm{bc} - \\boldsymbol{K}^{-1}(t)\\left[\\boldsymbol{K}(t)\\boldsymbol{x}_\\mathrm{bc}-\\boldsymbol{f}(t)\\right]
+= \\boldsymbol{K}^{-1}(t)\\boldsymbol{f}(t)
 ```
 is the solution to the current time step. This normally implies when using Ferrite the same procedure as for nonlinear problems, i.e. 
 that the boundary conditions are applied in `update_to_next_step!` and `update_problem!`, as well as the calculation of the residual 

--- a/src/problem.jl
+++ b/src/problem.jl
@@ -116,20 +116,11 @@ function check_convergence_criteria(problem, nlsolver, Δa, iter)
 end
 
 """
-    handle_converged!(problem)
-
-Do necessary update operations once it is known that the 
-problem has converged. E.g., update old values to the current. 
-Only called directly after the problem has converged. 
-"""
-function handle_converged! end
-
-"""
     postprocess!(problem, step, solver)
     postprocess!(problem, step)
 
 Perform any postprocessing at the current time and step nr `step`
-Called after time step converged, and after `handle_converged!`.
+Called after time step converged, and before `handle_converged!`.
 One can choose which version to overload, i.e. if the solver should be 
 given or not. 
 """
@@ -137,6 +128,15 @@ function postprocess! end
 postprocess!(problem, step, solver) = postprocess!(problem, step)
 postprocess!(args...) = nothing
 
+"""
+    handle_converged!(problem)
+
+Do necessary update operations once it is known that the 
+problem has converged. E.g., update old values to the current. 
+Only called directly after the problem has converged, 
+after `postprocess!`
+"""
+function handle_converged! end
 
 """
     setunknowns!(problem, x)

--- a/src/problem.jl
+++ b/src/problem.jl
@@ -65,16 +65,25 @@ time than the previous time if the solution did not converge.
 function update_to_next_step! end
 
 """
-    update_problem!(problem)
-    update_problem!(problem, Δx)
+    update_problem!(problem, Δx; update_residual::Bool, update_jacobian::Bool)
 
-Assemble the residual and stiffness for `x+=Δx`. 
+Update the unknowns, `x += Δx`, if `!isnothing(Δx)`, and in any case
+* Assemble the residual if `update_residual=true`
+* Assemble the jacobian if `update_jacobian=true`
 
-- Some linear solvers may be inaccurate, and if modified stiffness is used 
+Note that one can also update the residual and jacobian if any of the kwargs 
+are false, the kwargs just states if an update is required. 
+A simple function overload that doesn't account for the kwargs is
+```julia
+FESolvers.update_problem!(problem, Δx; kwargs...)
+```
+
+- Some linear solvers may be inaccurate, and if a modified stiffness is used 
   to enforce constraints on `x`, it is good the force `Δx=0` on these
   components inside this function. 
-- `Δx` is not given in the first call after [`update_to_next_step!`](@ref)
-  in which case no change of `x` should be made. 
+- `Δx=nothing` in the first call after [`update_to_next_step!`](@ref)
+  in which case, typically, no change of `x` should be made. Dirichlet
+  boundary conditions are typically updated in `update_to_next_step!`.
 """
 function update_problem! end
 


### PR DESCRIPTION
Creates a special "nlsolver" for linear problems that avoids re-assembly of stiffness to check if the problem converged. 
This PR introduces the following changes in addition
* Change order of `handle_converged` and `postprocess!` (`postprocess!` is now first)
* Adds kwargs to  `update_problem!` and send `nothing` instead of requiring default argument for user.
  With this change, the user should now define `FEProblems.update_problem!(p::MyProblem, dx; kwargs...)`, 
  and potentially using the bool kwargs: `update_jacobian` and `update_residual` (to avoid updating when not required)
