### PR TITLE
Follow julia-base convention

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FESolvers"
 uuid = "79314e9b-2e6f-4d6d-a72d-515aa2604984"
 authors = ["Knut Andreas Meyer and contributors"]
-version = "0.1.0"
+version = "0.2.0"
 
 [deps]
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 Package to easily solve nonlinear problem, in particularily tailored to [Ferrite.jl](https://github.com/Ferrite-FEM/Ferrite.jl).
 By defining `solver = QuasiStaticSolver(nlsolver, timestepper)`, the function 
 ```julia
-solve_problem!(solver::QuasiStaticSolver, problem)
+solve_problem!(problem, solver::QuasiStaticSolver)
 ```
 solves the user-defined `problem`. For this user defined type, 
 the following functions should be defined

--- a/docs/src/literate/plasticity.jl
+++ b/docs/src/literate/plasticity.jl
@@ -195,20 +195,20 @@ function example_solution()
     ## Fixed uniform time steps
     problem = build_problem(def)
     solver = QuasiStaticSolver(NewtonSolver(;tolerance=1.0), FixedTimeStepper(;num_steps=25,Δt=0.04))
-    solve_problem!(solver, problem)
+    solve_problem!(problem, solver)
     plt = plot_results(problem, label="uniform", markershape=:x, markersize=5)
 
     ## Same time steps as Ferrite example
     problem = build_problem(def)
     solver = QuasiStaticSolver(NewtonSolver(;tolerance=1.0), FixedTimeStepper(append!([0.], collect(0.5:0.05:1.0))))
-    solve_problem!(solver, problem)
+    solve_problem!(problem, solver)
     plot_results(problem, plt=plt, label="fixed", markershape=:circle)
 
     ## Adaptive time stepping 
     problem = build_problem(def)
     ts = AdaptiveTimeStepper(0.05, 1.0; Δt_min=0.01, Δt_max=0.2)
     solver = QuasiStaticSolver(NewtonSolver(;tolerance=1.0, maxiter=6), ts)
-    solve_problem!(solver, problem)
+    solve_problem!(problem, solver)
     println(problem.buf.time)
     plot_results(problem, plt=plt, label="adaptive", markershape=:circle)
     plot!(;legend=:bottomright)

--- a/docs/src/literate/transient_heat.jl
+++ b/docs/src/literate/transient_heat.jl
@@ -209,7 +209,7 @@ problem = TransientHeat(ProblemDefinition())
 solver = QuasiStaticSolver(;nlsolver=LinearProblemSolver(), timestepper=FixedTimeStepper(collect(0.0:1.0:200)));
 
 # Finally, we can solve the problem
-solve_problem!(solver, problem);
+solve_problem!(problem, solver);
 
 #md # ## [Plain program](@id transient_heat_equation-plain-program)
 #md #

--- a/src/FESolvers.jl
+++ b/src/FESolvers.jl
@@ -25,7 +25,7 @@ include("timesteppers.jl")
 include("QuasiStaticSolver.jl")
 
 """
-    solve_problem!(solver, problem)
+    solve_problem!(problem, solver)
 
 Solve a given user `problem` using the chosen `solver`
 

--- a/src/QuasiStaticSolver.jl
+++ b/src/QuasiStaticSolver.jl
@@ -39,7 +39,7 @@ function _solve_problem!(solver::QuasiStaticSolver, problem)
     while !islaststep(solver.timestepper, t, step)
         t, step = update_time(solver, t, step, converged)
         update_to_next_step!(problem, t)
-        converged = solve_nonlinear!(solver.nlsolver, problem)
+        converged = solve_nonlinear!(problem, solver.nlsolver)
         if converged
             copy!(xold, getunknowns(problem))
             postprocess!(problem, step, solver)

--- a/src/QuasiStaticSolver.jl
+++ b/src/QuasiStaticSolver.jl
@@ -15,7 +15,7 @@ getnlsolver(s::QuasiStaticSolver) = s.nlsolver
 gettimestepper(s::QuasiStaticSolver) = s.timestepper
 
 """
-    solve_problem!(solver, problem)
+    solve_problem!(problem, solver)
 
 Solve a time-dependent problem `r(x(t),t)=0` for `x(t)`, 
 stepping throught the time `t`, using the `solver`.
@@ -23,15 +23,15 @@ stepping throught the time `t`, using the `solver`.
 For details on the functions that should be defined for `problem`,
 see [User problem](@ref)
 """
-function solve_problem!(solver, problem)
+function solve_problem!(problem, solver)
     try
-        _solve_problem!(solver, problem)
+        _solve_problem!(problem, solver)
     finally
         close_problem(problem)
     end
 end
 
-function _solve_problem!(solver::QuasiStaticSolver, problem)
+function _solve_problem!(problem, solver::QuasiStaticSolver)
     t = initial_time(solver.timestepper)
     step = 1
     converged = true

--- a/src/nlsolvers.jl
+++ b/src/nlsolvers.jl
@@ -1,5 +1,5 @@
 """
-    solve_nonlinear!(nlsolver, problem)
+    solve_nonlinear!(problem, nlsolver)
 
 Solve the current time step in the nonlinear `problem`, (`r(x) = 0`),
 by using the nonlinear solver: `nlsolver`. 
@@ -122,7 +122,7 @@ function update_state!(s::Union{NewtonSolver,SteepestDescent}, r)
     s.residuals[s.numiter[]] = r 
 end
 
-function solve_nonlinear!(nlsolver, problem)
+function solve_nonlinear!(problem, nlsolver)
     maxiter = getmaxiter(nlsolver)
     reset_state!(nlsolver)
     update_problem!(problem, nothing; update_residual=true, update_jacobian=true)
@@ -177,7 +177,7 @@ LinearProblemSolver(;linsolver=BackslashSolver()) = LinearProblemSolver(linsolve
 
 getsystemmatrix(problem, ::LinearProblemSolver) = getjacobian(problem)
 
-function solve_nonlinear!(nlsolver::LinearProblemSolver, problem)
+function solve_nonlinear!(problem, nlsolver::LinearProblemSolver)
     update_problem!(problem, nothing; update_residual=true, update_jacobian=true)
     r = getresidual(problem)
     K = getsystemmatrix(problem,nlsolver)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,7 +17,7 @@ include("test_timesteppers.jl")
     problem = TestProblem()
     timehist = [0.0, 1.0, 2.0, 3.0]
     solver = QuasiStaticSolver(nlsolver=NewtonSolver(;tolerance=tol), timestepper=FixedTimeStepper(timehist))
-    solve_problem!(solver, problem)    
+    solve_problem!(problem, solver)    
     
     @test problem.tv ≈ timehist[2:end]  # First time not postprocessed currently, should it?
     @test length(problem.conv) == (length(timehist)-1)  # Check handle_converged calls
@@ -27,7 +27,7 @@ include("test_timesteppers.jl")
 
     problem = TestProblem(;throw_at_step=3)
     FESolvers.close_problem(p::TestProblem) = push!(p.steps, -1)
-    @test_throws TestError solve_problem!(solver, problem)
+    @test_throws TestError solve_problem!(problem, solver)
     @test length(problem.steps) == 2
     @test last(problem.steps) == -1
 
@@ -35,7 +35,7 @@ include("test_timesteppers.jl")
     k = 1.0
     p_linear = LinearTestProblem(k;dbcfun=t->0.1*t)
     s_linear = QuasiStaticSolver(nlsolver=LinearProblemSolver(), timestepper=FixedTimeStepper(timehist))
-    solve_problem!(s_linear, p_linear)
+    solve_problem!(p_linear, s_linear)
     
     ubc = 0.1*timehist   # Boundary condition 
     # Two springs in series, stiffness is k/2. Displacement Δu = 2f/k

--- a/test/test_nlsolvers.jl
+++ b/test/test_nlsolvers.jl
@@ -7,7 +7,7 @@
     custom = TestNLSolver(;maxiter=30, tolerance=tol, ls=ls)
     for nlsolver in [steepestdescent, newton_ls, newton, custom]
         problem = Rosenbrock() 
-        converged = FESolvers.solve_nonlinear!(nlsolver, problem)
+        converged = FESolvers.solve_nonlinear!(problem, nlsolver)
         @test converged
         @test isapprox(norm(problem.r), 0.0; atol=1e-2)
         @test all(isapprox.(problem.x, 1.0; atol=1e-5))
@@ -15,6 +15,6 @@
 
     # Test that it runs properly when it doesn't converge 
     newton = NewtonSolver(;tolerance=-1.0)
-    converged = FESolvers.solve_nonlinear!(newton, Rosenbrock())
+    converged = FESolvers.solve_nonlinear!(Rosenbrock(), newton)
     @test !converged
 end


### PR DESCRIPTION
By mistake the original definition of `solve_problem!` was `solve_problem!(solver, problem)`, 
but following Julia's [Style Guide](https://docs.julialang.org/en/v1/manual/style-guide/#Write-functions-with-argument-ordering-similar-to-Julia-Base) it should be reversed. Better do it now than later...
I.e. change to `solve_problem!(problem, solver)`
Will bump the version soon after merging this...