### PR TITLE
Kam/postprocessfirst

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ and the jacobian can be updated. Keep looping over the iterations until
 `calculate_convergence_measure` returns a sufficiently small value.
 
 ### After convergence
-The first thing that happens after convergence is that the user-defined function 
+The first thing that happens after convergence (also directly after calling `solve_problem`) is that the user-defined function 
 ```julia
 postprocess!(problem, step, [solver])   # Optional to define with or without solver
 ```

--- a/src/QuasiStaticSolver.jl
+++ b/src/QuasiStaticSolver.jl
@@ -36,6 +36,7 @@ function _solve_problem!(problem, solver::QuasiStaticSolver)
     step = 1
     converged = true
     xold = deepcopy(getunknowns(problem))
+    postprocess!(problem, step, solver)
     while !islaststep(solver.timestepper, t, step)
         t, step = update_time(solver, t, step, converged)
         update_to_next_step!(problem, t)
@@ -47,8 +48,6 @@ function _solve_problem!(problem, solver::QuasiStaticSolver)
         else
             # Reset unknowns if it didn't converge to 
             setunknowns!(problem, xold)
-            # TODO: ProgressMeter
-            println("the nonlinear solver didn't converge")
         end
     end
 end

--- a/src/problem.jl
+++ b/src/problem.jl
@@ -120,7 +120,8 @@ end
     postprocess!(problem, step)
 
 Perform any postprocessing at the current time and step nr `step`
-Called after time step converged, and before `handle_converged!`.
+Called at the beginning of the simulation, 
+and after time step converged right before `handle_converged!`.
 One can choose which version to overload, i.e. if the solver should be 
 given or not. 
 """

--- a/test/testproblem.jl
+++ b/test/testproblem.jl
@@ -1,12 +1,13 @@
 using ForwardDiff, LinearAlgebra
 # Test problem
 #= 
-    | exp(t) - norm(x+1) |           | -norm(x .+ 1) |
-r = | cos(t) + x[1]      | = f(t) +  | x[1]          |
-    | x[3]^2 - x[2]      |           | x[3]^2-x[2]   |
+    | (exp(t)-1) - (norm(x+1)-1) |           | √3-norm(x .+ 1) |
+r = | (cos(t)-1) + x[1]          | = f(t) +  | x[1]            |
+    | x[3]^2 - x[2]              |           | x[3]^2-x[2]     |
 =#
 safenorm(x) = sqrt(sum(y->y^2+eps(y),x))    # Avoid NaN in derivative at x=0
-residual(x, f) = f + [-safenorm(x .+ 1); x[1]; x[3]^2-x[2]]
+residual(x, f) = f + [safenorm(ones(3))-safenorm(x .+ 1); x[1]; x[3]^2-x[2]]
+timefun(t) = [exp(t)-1; cos(t)-1; zero(t)]
 
 struct TestError <: Exception end
 
@@ -27,7 +28,7 @@ struct TestProblem{T,FT}
 end
 TestProblem(;throw_at_step=-1) = TestProblem(
     zeros(3), zeros(3), zeros(3,3), # x, r, drdx
-    t->[exp(t); cos(t); zero(t)],   # fun
+    timefun,                        # fun
     zeros(3), zeros(1),             # f, time
     Vector{Float64}[], Vector{Float64}[], Float64[], Int[], Bool[], throw_at_step
     )


### PR DESCRIPTION
Add call to `postprocess!` at the first step (before solving anything). 
Since it is more common than not to want the initial state postprocess, this is a more convenient default, and to not do this, users can add a simple `step==1 && return nothing` in the beginning of their `postprocess!` function. 