### PR TITLE
Avoid early exit when last step not converging

### DIFF
--- a/src/QuasiStaticSolver.jl
+++ b/src/QuasiStaticSolver.jl
@@ -37,7 +37,7 @@ function _solve_problem!(problem, solver::QuasiStaticSolver)
     converged = true
     xold = deepcopy(getunknowns(problem))
     postprocess!(problem, step, solver)
-    while !islaststep(solver.timestepper, t, step)
+    while !(converged && islaststep(solver.timestepper, t, step))
         t, step = update_time(solver, t, step, converged)
         update_to_next_step!(problem, t)
         converged = solve_nonlinear!(problem, solver.nlsolver)

--- a/test/test_timesteppers.jl
+++ b/test/test_timesteppers.jl
@@ -1,4 +1,4 @@
-function run_timestepper(solver, convergence_function)
+function run_timestepper(solver, convergence_function=Returns(true))
     t = FESolvers.initial_time(solver.timestepper)
     t_old = t
     step = 1


### PR DESCRIPTION
Solves #21 and in the process found a bug that if the last step didn't converge when attempting the last time step, the time loop would still exit even if not converged. This is now fixed and tested for. 