### PR TITLE
Kam/adaptive solving

### DIFF
--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -1,6 +1,6 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.8.5"
+julia_version = "1.9.1"
 manifest_format = "2.0"
 project_hash = "aedb8c1b021f4165529ffe5c59e70ce3cc471edf"
 
@@ -36,18 +36,6 @@ git-tree-sha1 = "4b859a208b2397a7a623a03449e4636bdb17bcf2"
 uuid = "83423d85-b0ee-5818-9007-b63ccbeb887a"
 version = "1.16.1+1"
 
-[[deps.ChainRulesCore]]
-deps = ["Compat", "LinearAlgebra", "SparseArrays"]
-git-tree-sha1 = "c6d890a52d2c4d55d326439580c3b8d0875a77d9"
-uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "1.15.7"
-
-[[deps.ChangesOfVariables]]
-deps = ["ChainRulesCore", "LinearAlgebra", "Test"]
-git-tree-sha1 = "844b061c104c408b24537482469400af6075aae4"
-uuid = "9e997f8a-9a97-42d5-a9f1-ce6bfc15e2c0"
-version = "0.1.5"
-
 [[deps.CodecZlib]]
 deps = ["TranscodingStreams", "Zlib_jll"]
 git-tree-sha1 = "9c209fb7536406834aa938fb149964b985de6c83"
@@ -55,10 +43,10 @@ uuid = "944b1d66-785c-5afd-91f1-9de20f533193"
 version = "0.7.1"
 
 [[deps.ColorSchemes]]
-deps = ["ColorTypes", "ColorVectorSpace", "Colors", "FixedPointNumbers", "Random", "SnoopPrecompile"]
-git-tree-sha1 = "aa3edc8f8dea6cbfa176ee12f7c2fc82f0608ed3"
+deps = ["ColorTypes", "ColorVectorSpace", "Colors", "FixedPointNumbers", "PrecompileTools", "Random"]
+git-tree-sha1 = "be6ab11021cd29f0344d5c4357b163af05a48cba"
 uuid = "35d6a980-a343-548e-a6ea-1d62b119f2f4"
-version = "3.20.0"
+version = "3.21.0"
 
 [[deps.ColorTypes]]
 deps = ["FixedPointNumbers", "Random"]
@@ -85,15 +73,39 @@ uuid = "bbf7d656-a473-5ed7-a52c-81e309532950"
 version = "0.3.0"
 
 [[deps.Compat]]
-deps = ["Dates", "LinearAlgebra", "UUIDs"]
-git-tree-sha1 = "00a2cccc7f098ff3b66806862d275ca3db9e6e5a"
+deps = ["UUIDs"]
+git-tree-sha1 = "7a60c856b9fa189eb34f5f8a6f6b5529b7942957"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "4.5.0"
+version = "4.6.1"
+weakdeps = ["Dates", "LinearAlgebra"]
+
+    [deps.Compat.extensions]
+    CompatLinearAlgebraExt = "LinearAlgebra"
 
 [[deps.CompilerSupportLibraries_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
-version = "1.0.1+0"
+version = "1.0.2+0"
+
+[[deps.ConcurrentUtilities]]
+deps = ["Serialization", "Sockets"]
+git-tree-sha1 = "96d823b94ba8d187a6d8f0826e731195a74b90e9"
+uuid = "f0e56b4a-5159-44fe-b623-3e5288b988bb"
+version = "2.2.0"
+
+[[deps.ConstructionBase]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "738fec4d684a9a6ee9598a8bfee305b26831f28c"
+uuid = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
+version = "1.5.2"
+
+    [deps.ConstructionBase.extensions]
+    ConstructionBaseIntervalSetsExt = "IntervalSets"
+    ConstructionBaseStaticArraysExt = "StaticArrays"
+
+    [deps.ConstructionBase.weakdeps]
+    IntervalSets = "8197267c-284f-5f27-9208-e0e47529a953"
+    StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [[deps.Contour]]
 git-tree-sha1 = "d05d9e7b7aedff4e5b51a029dced05cfb6125781"
@@ -101,9 +113,9 @@ uuid = "d38c429a-6771-53c6-b99e-75d170b6e991"
 version = "0.6.2"
 
 [[deps.DataAPI]]
-git-tree-sha1 = "e8119c1a33d267e16108be441a287a6981ba1630"
+git-tree-sha1 = "8da84edb865b0b5b0100c0666a9bc9a0b71c553c"
 uuid = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
-version = "1.14.0"
+version = "1.15.0"
 
 [[deps.DataStructures]]
 deps = ["Compat", "InteractiveUtils", "OrderedCollections"]
@@ -117,7 +129,9 @@ uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
 
 [[deps.DelimitedFiles]]
 deps = ["Mmap"]
+git-tree-sha1 = "9e2f36d3c96a820c678f2f1f1782582fcf685bae"
 uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+version = "1.9.1"
 
 [[deps.DiffResults]]
 deps = ["StaticArraysCore"]
@@ -127,27 +141,27 @@ version = "1.1.0"
 
 [[deps.DiffRules]]
 deps = ["IrrationalConstants", "LogExpFunctions", "NaNMath", "Random", "SpecialFunctions"]
-git-tree-sha1 = "c5b6685d53f933c11404a3ae9822afe30d522494"
+git-tree-sha1 = "23163d55f885173722d1e4cf0f6110cdbaf7e272"
 uuid = "b552c78f-8df3-52c6-915a-8e097449b14b"
-version = "1.12.2"
+version = "1.15.1"
 
 [[deps.Distances]]
 deps = ["LinearAlgebra", "SparseArrays", "Statistics", "StatsAPI"]
-git-tree-sha1 = "3258d0659f812acde79e8a74b11f17ac06d0ca04"
+git-tree-sha1 = "49eba9ad9f7ead780bfb7ee319f962c811c6d3b2"
 uuid = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
-version = "0.10.7"
+version = "0.10.8"
 
 [[deps.DocStringExtensions]]
 deps = ["LibGit2"]
-git-tree-sha1 = "b19534d1895d702889b219c382a6e18010797f0b"
+git-tree-sha1 = "2fb1e02f2b635d0845df5d7c167fec4dd739b00d"
 uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
-version = "0.8.6"
+version = "0.9.3"
 
 [[deps.Documenter]]
 deps = ["ANSIColoredPrinters", "Base64", "Dates", "DocStringExtensions", "IOCapture", "InteractiveUtils", "JSON", "LibGit2", "Logging", "Markdown", "REPL", "Test", "Unicode"]
-git-tree-sha1 = "2498c3704e9cd26bf586a351473417881676bb2d"
+git-tree-sha1 = "58fea7c536acd71f3eef6be3b21c0df5f3df88fd"
 uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-version = "0.27.21"
+version = "0.27.24"
 
 [[deps.Downloads]]
 deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]
@@ -169,7 +183,7 @@ version = "2.4.8+0"
 deps = ["ForwardDiff", "LinearAlgebra", "Requires"]
 path = ".."
 uuid = "79314e9b-2e6f-4d6d-a72d-515aa2604984"
-version = "0.2.0"
+version = "0.2.2"
 
 [[deps.FFMPEG]]
 deps = ["FFMPEG_jll"]
@@ -185,18 +199,26 @@ version = "4.4.2+2"
 
 [[deps.Ferrite]]
 deps = ["EnumX", "LinearAlgebra", "NearestNeighbors", "Preferences", "Reexport", "SparseArrays", "Tensors", "WriteVTK"]
-git-tree-sha1 = "19787ed1e790736e6bffc34c07289f63fbb19e1a"
+git-tree-sha1 = "a31b9d4dd58e00686e5da175dab11667af3108b6"
 uuid = "c061ca5d-56c9-439f-9c0e-210fe06d3992"
-version = "0.3.11"
+version = "0.3.14"
+
+    [deps.Ferrite.extensions]
+    FerriteBlockArrays = "BlockArrays"
+    FerriteMetis = "Metis"
+
+    [deps.Ferrite.weakdeps]
+    BlockArrays = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
+    Metis = "2679e427-3c69-5b7f-982b-ece356f1e94b"
 
 [[deps.FileWatching]]
 uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
 
 [[deps.FillArrays]]
 deps = ["LinearAlgebra", "Random", "SparseArrays", "Statistics"]
-git-tree-sha1 = "d3ba08ab64bdfd27234d3f61956c966266757fe6"
+git-tree-sha1 = "589d3d3bff204bdd80ecc53293896b4f39175723"
 uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
-version = "0.13.7"
+version = "1.1.1"
 
 [[deps.FixedPointNumbers]]
 deps = ["Statistics"]
@@ -217,10 +239,14 @@ uuid = "59287772-0a20-5a39-b81b-1366585eb4c0"
 version = "0.4.2"
 
 [[deps.ForwardDiff]]
-deps = ["CommonSubexpressions", "DiffResults", "DiffRules", "LinearAlgebra", "LogExpFunctions", "NaNMath", "Preferences", "Printf", "Random", "SpecialFunctions", "StaticArrays"]
-git-tree-sha1 = "a69dd6db8a809f78846ff259298678f0d6212180"
+deps = ["CommonSubexpressions", "DiffResults", "DiffRules", "LinearAlgebra", "LogExpFunctions", "NaNMath", "Preferences", "Printf", "Random", "SpecialFunctions"]
+git-tree-sha1 = "00e252f4d706b3d55a8863432e742bf5717b498d"
 uuid = "f6369f11-7733-5829-9624-2563aa707210"
-version = "0.10.34"
+version = "0.10.35"
+weakdeps = ["StaticArrays"]
+
+    [deps.ForwardDiff.extensions]
+    ForwardDiffStaticArraysExt = "StaticArrays"
 
 [[deps.FreeType2_jll]]
 deps = ["Artifacts", "Bzip2_jll", "JLLWrappers", "Libdl", "Pkg", "Zlib_jll"]
@@ -241,16 +267,16 @@ uuid = "0656b61e-2033-5cc2-a64a-77c0f6c09b89"
 version = "3.3.8+0"
 
 [[deps.GR]]
-deps = ["Base64", "DelimitedFiles", "GR_jll", "HTTP", "JSON", "Libdl", "LinearAlgebra", "Pkg", "Printf", "Random", "RelocatableFolders", "Serialization", "Sockets", "Test", "UUIDs"]
-git-tree-sha1 = "0ac6f27e784059c68b987f42b909ade0bcfabe69"
+deps = ["Artifacts", "Base64", "DelimitedFiles", "Downloads", "GR_jll", "HTTP", "JSON", "Libdl", "LinearAlgebra", "Pkg", "Preferences", "Printf", "Random", "Serialization", "Sockets", "TOML", "Tar", "Test", "UUIDs", "p7zip_jll"]
+git-tree-sha1 = "8b8a2fd4536ece6e554168c21860b6820a8a83db"
 uuid = "28b8d3ca-fb5f-59d9-8090-bfdbd6d07a71"
-version = "0.68.0"
+version = "0.72.7"
 
 [[deps.GR_jll]]
-deps = ["Artifacts", "Bzip2_jll", "Cairo_jll", "FFMPEG_jll", "Fontconfig_jll", "GLFW_jll", "JLLWrappers", "JpegTurbo_jll", "Libdl", "Libtiff_jll", "Pixman_jll", "Pkg", "Qt5Base_jll", "Zlib_jll", "libpng_jll"]
-git-tree-sha1 = "bc9f7725571ddb4ab2c4bc74fa397c1c5ad08943"
+deps = ["Artifacts", "Bzip2_jll", "Cairo_jll", "FFMPEG_jll", "Fontconfig_jll", "GLFW_jll", "JLLWrappers", "JpegTurbo_jll", "Libdl", "Libtiff_jll", "Pixman_jll", "Qt5Base_jll", "Zlib_jll", "libpng_jll"]
+git-tree-sha1 = "19fad9cd9ae44847fe842558a744748084a722d1"
 uuid = "d2c73de3-f751-5644-a686-071e5b155ba9"
-version = "0.69.1+0"
+version = "0.72.7+0"
 
 [[deps.Gettext_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "Libiconv_jll", "Pkg", "XML2_jll"]
@@ -276,10 +302,10 @@ uuid = "42e2da0e-8278-4e71-bc24-59509adca0fe"
 version = "1.0.2"
 
 [[deps.HTTP]]
-deps = ["Base64", "CodecZlib", "Dates", "IniFile", "Logging", "LoggingExtras", "MbedTLS", "NetworkOptions", "OpenSSL", "Random", "SimpleBufferStream", "Sockets", "URIs", "UUIDs"]
-git-tree-sha1 = "37e4657cd56b11abe3d10cd4a1ec5fbdb4180263"
+deps = ["Base64", "CodecZlib", "ConcurrentUtilities", "Dates", "Logging", "LoggingExtras", "MbedTLS", "NetworkOptions", "OpenSSL", "Random", "SimpleBufferStream", "Sockets", "URIs", "UUIDs"]
+git-tree-sha1 = "5e77dbf117412d4f164a464d610ee6050cc75272"
 uuid = "cd3eb016-35fb-5094-929b-558a96fad6f3"
-version = "1.7.4"
+version = "1.9.6"
 
 [[deps.HarfBuzz_jll]]
 deps = ["Artifacts", "Cairo_jll", "Fontconfig_jll", "FreeType2_jll", "Glib_jll", "Graphite2_jll", "JLLWrappers", "Libdl", "Libffi_jll", "Pkg"]
@@ -289,29 +315,18 @@ version = "2.8.1+1"
 
 [[deps.IOCapture]]
 deps = ["Logging", "Random"]
-git-tree-sha1 = "f7be53659ab06ddc986428d3a9dcc95f6fa6705a"
+git-tree-sha1 = "d75853a0bdbfb1ac815478bacd89cd27b550ace6"
 uuid = "b5f81e59-6552-4d32-b1f0-c071b021bf89"
-version = "0.2.2"
-
-[[deps.IniFile]]
-git-tree-sha1 = "f550e6e32074c939295eb5ea6de31849ac2c9625"
-uuid = "83e8ac13-25f8-5344-8a64-a9f2b223428f"
-version = "0.5.1"
+version = "0.2.3"
 
 [[deps.InteractiveUtils]]
 deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
-[[deps.InverseFunctions]]
-deps = ["Test"]
-git-tree-sha1 = "49510dfcb407e572524ba94aeae2fced1f3feb0f"
-uuid = "3587e190-3f89-42d0-90ee-14403ec27112"
-version = "0.1.8"
-
 [[deps.IrrationalConstants]]
-git-tree-sha1 = "7fd44fd4ff43fc60815f8e764c0f352b83c49151"
+git-tree-sha1 = "630b497eafcc20001bba38a4651b327dcfc491d2"
 uuid = "92d709cd-6900-40b7-9082-c6be49f344b6"
-version = "0.1.1"
+version = "0.2.2"
 
 [[deps.JLFzf]]
 deps = ["Pipe", "REPL", "Random", "fzf_jll"]
@@ -327,15 +342,15 @@ version = "1.4.1"
 
 [[deps.JSON]]
 deps = ["Dates", "Mmap", "Parsers", "Unicode"]
-git-tree-sha1 = "3c837543ddb02250ef42f4738347454f95079d4e"
+git-tree-sha1 = "31e996f0a15c7b280ba9f76636b3ff9e2ae58c9a"
 uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
-version = "0.21.3"
+version = "0.21.4"
 
 [[deps.JpegTurbo_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "b53380851c6e6664204efb2e62cd24fa5c47e4ba"
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "6f2675ef130a300a112286de91973805fcc5ffbc"
 uuid = "aacddb02-875f-59d6-b918-886e6ef4fbf8"
-version = "2.1.2+0"
+version = "2.1.91+0"
 
 [[deps.LAME_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
@@ -348,6 +363,12 @@ deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
 git-tree-sha1 = "bf36f528eec6634efc60d7ec062008f171071434"
 uuid = "88015f11-f218-50d7-93a8-a6af411a945d"
 version = "3.0.0+1"
+
+[[deps.LLVMOpenMP_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "f689897ccbe049adb19a065c495e75f372ecd42b"
+uuid = "1d63c593-3942-5779-bab2-d838dc0a180e"
+version = "15.0.4+0"
 
 [[deps.LZO_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
@@ -362,9 +383,17 @@ version = "1.3.0"
 
 [[deps.Latexify]]
 deps = ["Formatting", "InteractiveUtils", "LaTeXStrings", "MacroTools", "Markdown", "OrderedCollections", "Printf", "Requires"]
-git-tree-sha1 = "2422f47b34d4b127720a18f86fa7b1aa2e141f29"
+git-tree-sha1 = "f428ae552340899a935973270b8d98e5a31c49fe"
 uuid = "23fbe1c1-3f47-55db-b15f-69d7ec21a316"
-version = "0.15.18"
+version = "0.16.1"
+
+    [deps.Latexify.extensions]
+    DataFramesExt = "DataFrames"
+    SymEngineExt = "SymEngine"
+
+    [deps.Latexify.weakdeps]
+    DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+    SymEngine = "123dc426-2d89-5057-bbad-38513e3affd8"
 
 [[deps.LibCURL]]
 deps = ["LibCURL_jll", "MozillaCACerts_jll"]
@@ -443,7 +472,7 @@ uuid = "9c8b4983-aa76-5018-a973-4c85ecc9e179"
 version = "0.9.0"
 
 [[deps.LinearAlgebra]]
-deps = ["Libdl", "libblastrampoline_jll"]
+deps = ["Libdl", "OpenBLAS_jll", "libblastrampoline_jll"]
 uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [[deps.Literate]]
@@ -453,10 +482,20 @@ uuid = "98b081ad-f1c9-55d3-8b20-4c87d4299306"
 version = "2.14.0"
 
 [[deps.LogExpFunctions]]
-deps = ["ChainRulesCore", "ChangesOfVariables", "DocStringExtensions", "InverseFunctions", "IrrationalConstants", "LinearAlgebra"]
-git-tree-sha1 = "45b288af6956e67e621c5cbb2d75a261ab58300b"
+deps = ["DocStringExtensions", "IrrationalConstants", "LinearAlgebra"]
+git-tree-sha1 = "c3ce8e7420b3a6e071e0fe4745f5d4300e37b13f"
 uuid = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
-version = "0.3.20"
+version = "0.3.24"
+
+    [deps.LogExpFunctions.extensions]
+    LogExpFunctionsChainRulesCoreExt = "ChainRulesCore"
+    LogExpFunctionsChangesOfVariablesExt = "ChangesOfVariables"
+    LogExpFunctionsInverseFunctionsExt = "InverseFunctions"
+
+    [deps.LogExpFunctions.weakdeps]
+    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+    ChangesOfVariables = "9e997f8a-9a97-42d5-a9f1-ce6bfc15e2c0"
+    InverseFunctions = "3587e190-3f89-42d0-90ee-14403ec27112"
 
 [[deps.Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
@@ -486,7 +525,7 @@ version = "1.1.7"
 [[deps.MbedTLS_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
-version = "2.28.0+0"
+version = "2.28.2+0"
 
 [[deps.Measures]]
 git-tree-sha1 = "c13304c81eec1ed3af7fc20e75fb6b26092a1102"
@@ -504,13 +543,13 @@ uuid = "a63ad114-7e13-5084-954f-fe012c677804"
 
 [[deps.MozillaCACerts_jll]]
 uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
-version = "2022.2.1"
+version = "2022.10.11"
 
 [[deps.NaNMath]]
 deps = ["OpenLibm_jll"]
-git-tree-sha1 = "a7c3d1da1189a1c2fe843a3bfa04d18d20eb3211"
+git-tree-sha1 = "0877504529a3e5c3343c6f8b4c0381e57e4387e4"
 uuid = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
-version = "1.0.1"
+version = "1.0.2"
 
 [[deps.NearestNeighbors]]
 deps = ["Distances", "StaticArrays"]
@@ -531,7 +570,7 @@ version = "1.3.5+1"
 [[deps.OpenBLAS_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
 uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
-version = "0.3.20+0"
+version = "0.3.21+4"
 
 [[deps.OpenLibm_jll]]
 deps = ["Artifacts", "Libdl"]
@@ -540,15 +579,15 @@ version = "0.8.1+0"
 
 [[deps.OpenSSL]]
 deps = ["BitFlags", "Dates", "MozillaCACerts_jll", "OpenSSL_jll", "Sockets"]
-git-tree-sha1 = "6503b77492fd7fcb9379bf73cd31035670e3c509"
+git-tree-sha1 = "51901a49222b09e3743c65b8847687ae5fc78eb2"
 uuid = "4d8831e6-92b7-49fb-bdf8-b643e874388c"
-version = "1.3.3"
+version = "1.4.1"
 
 [[deps.OpenSSL_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "f6e9dba33f9f2c44e08a020b0caf6903be540004"
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "1aa4b74f80b01c6bc2b89992b861b5f210e665b5"
 uuid = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
-version = "1.1.19+0"
+version = "1.1.21+0"
 
 [[deps.OpenSpecFun_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "Pkg"]
@@ -563,20 +602,20 @@ uuid = "91d4177d-7536-5919-b921-800302f37372"
 version = "1.3.2+0"
 
 [[deps.OrderedCollections]]
-git-tree-sha1 = "85f8e6578bf1f9ee0d11e7bb1b1456435479d47c"
+git-tree-sha1 = "d321bf2de576bf25ec4d3e4360faca399afca282"
 uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
-version = "1.4.1"
+version = "1.6.0"
 
 [[deps.PCRE2_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "efcefdf7-47ab-520b-bdef-62a2eaa19f15"
-version = "10.40.0+0"
+version = "10.42.0+0"
 
 [[deps.Parsers]]
-deps = ["Dates", "SnoopPrecompile"]
-git-tree-sha1 = "8175fc2b118a3755113c8e68084dc1a9e63c61ee"
+deps = ["Dates", "PrecompileTools", "UUIDs"]
+git-tree-sha1 = "b32107a634205cdcc64e2a3070c3eb0d56d54181"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "2.5.3"
+version = "2.6.0"
 
 [[deps.Pipe]]
 git-tree-sha1 = "6842804e7867b115ca9de748a0cf6b364523c16d"
@@ -584,15 +623,15 @@ uuid = "b98c9c47-44ae-5843-9183-064241ee97a0"
 version = "1.3.0"
 
 [[deps.Pixman_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "b4f5d02549a10e20780a24fce72bea96b6329e29"
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "LLVMOpenMP_jll", "Libdl"]
+git-tree-sha1 = "64779bc4c9784fee475689a1752ef4d5747c5e87"
 uuid = "30392449-352a-5448-841d-b1acce4e97dc"
-version = "0.40.1+0"
+version = "0.42.2+0"
 
 [[deps.Pkg]]
-deps = ["Artifacts", "Dates", "Downloads", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
+deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-version = "1.8.0"
+version = "1.9.0"
 
 [[deps.PlotThemes]]
 deps = ["PlotUtils", "Statistics"]
@@ -601,22 +640,42 @@ uuid = "ccf2f8ad-2431-5c83-bf29-c5338b663b6a"
 version = "3.1.0"
 
 [[deps.PlotUtils]]
-deps = ["ColorSchemes", "Colors", "Dates", "Printf", "Random", "Reexport", "SnoopPrecompile", "Statistics"]
-git-tree-sha1 = "c95373e73290cf50a8a22c3375e4625ded5c5280"
+deps = ["ColorSchemes", "Colors", "Dates", "PrecompileTools", "Printf", "Random", "Reexport", "Statistics"]
+git-tree-sha1 = "f92e1315dadf8c46561fb9396e525f7200cdc227"
 uuid = "995b91a9-d308-5afd-9ec6-746e21dbc043"
-version = "1.3.4"
+version = "1.3.5"
 
 [[deps.Plots]]
-deps = ["Base64", "Contour", "Dates", "Downloads", "FFMPEG", "FixedPointNumbers", "GR", "JLFzf", "JSON", "LaTeXStrings", "Latexify", "LinearAlgebra", "Measures", "NaNMath", "Pkg", "PlotThemes", "PlotUtils", "Printf", "REPL", "Random", "RecipesBase", "RecipesPipeline", "Reexport", "RelocatableFolders", "Requires", "Scratch", "Showoff", "SnoopPrecompile", "SparseArrays", "Statistics", "StatsBase", "UUIDs", "UnicodeFun", "Unzip"]
-git-tree-sha1 = "6fae75c2178132582ea261d39f6da50cdd09c3c6"
+deps = ["Base64", "Contour", "Dates", "Downloads", "FFMPEG", "FixedPointNumbers", "GR", "JLFzf", "JSON", "LaTeXStrings", "Latexify", "LinearAlgebra", "Measures", "NaNMath", "Pkg", "PlotThemes", "PlotUtils", "PrecompileTools", "Preferences", "Printf", "REPL", "Random", "RecipesBase", "RecipesPipeline", "Reexport", "RelocatableFolders", "Requires", "Scratch", "Showoff", "SparseArrays", "Statistics", "StatsBase", "UUIDs", "UnicodeFun", "UnitfulLatexify", "Unzip"]
+git-tree-sha1 = "75ca67b2c6512ad2d0c767a7cfc55e75075f8bbc"
 uuid = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
-version = "1.34.0"
+version = "1.38.16"
+
+    [deps.Plots.extensions]
+    FileIOExt = "FileIO"
+    GeometryBasicsExt = "GeometryBasics"
+    IJuliaExt = "IJulia"
+    ImageInTerminalExt = "ImageInTerminal"
+    UnitfulExt = "Unitful"
+
+    [deps.Plots.weakdeps]
+    FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
+    GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
+    IJulia = "7073ff75-c697-5162-941a-fcdaad2a7d2a"
+    ImageInTerminal = "d8c32880-2388-543b-8c61-d9f865259254"
+    Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
+
+[[deps.PrecompileTools]]
+deps = ["Preferences"]
+git-tree-sha1 = "9673d39decc5feece56ef3940e5dafba15ba0f81"
+uuid = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
+version = "1.1.2"
 
 [[deps.Preferences]]
 deps = ["TOML"]
-git-tree-sha1 = "47e5f437cc0e7ef2ce8406ce1e7e24d44915f88d"
+git-tree-sha1 = "7eb1686b4f04b82f96ed7a4ea5890a4f0c7a09f1"
 uuid = "21216c6a-2e73-6563-6e65-726566657250"
-version = "1.3.0"
+version = "1.4.0"
 
 [[deps.Printf]]
 deps = ["Unicode"]
@@ -637,16 +696,16 @@ deps = ["SHA", "Serialization"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [[deps.RecipesBase]]
-deps = ["SnoopPrecompile"]
-git-tree-sha1 = "261dddd3b862bd2c940cf6ca4d1c8fe593e457c8"
+deps = ["PrecompileTools"]
+git-tree-sha1 = "5c3d09cc4f31f5fc6af001c250bf1278733100ff"
 uuid = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
-version = "1.3.3"
+version = "1.3.4"
 
 [[deps.RecipesPipeline]]
-deps = ["Dates", "NaNMath", "PlotUtils", "RecipesBase", "SnoopPrecompile"]
-git-tree-sha1 = "e974477be88cb5e3040009f3767611bc6357846f"
+deps = ["Dates", "NaNMath", "PlotUtils", "PrecompileTools", "RecipesBase"]
+git-tree-sha1 = "45cf9fd0ca5839d06ef333c8201714e888486342"
 uuid = "01d81517-befc-4cb6-b9ec-a95719d0359c"
-version = "0.6.11"
+version = "0.6.12"
 
 [[deps.Reexport]]
 git-tree-sha1 = "45e428421666073eab6f2da5c9d310d99bb12f9b"
@@ -670,16 +729,16 @@ uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 version = "0.7.0"
 
 [[deps.SIMD]]
-deps = ["SnoopPrecompile"]
-git-tree-sha1 = "8b20084a97b004588125caebf418d8cab9e393d1"
+deps = ["PrecompileTools"]
+git-tree-sha1 = "0e270732477b9e551d884e6b07e23bb2ec947790"
 uuid = "fdea26ae-647d-5447-a871-4b548cad5224"
-version = "3.4.4"
+version = "3.4.5"
 
 [[deps.Scratch]]
 deps = ["Dates"]
-git-tree-sha1 = "f94f779c94e58bf9ea243e77a37e16d9de9126bd"
+git-tree-sha1 = "30449ee12237627992a99d5e30ae63e4d78cd24a"
 uuid = "6c6a2e73-6563-6170-7368-637461726353"
-version = "1.1.1"
+version = "1.2.0"
 
 [[deps.Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
@@ -695,12 +754,6 @@ git-tree-sha1 = "874e8867b33a00e784c8a7e4b60afe9e037b74e1"
 uuid = "777ac1f9-54b0-4bf8-805c-2214025038e7"
 version = "1.1.0"
 
-[[deps.SnoopPrecompile]]
-deps = ["Preferences"]
-git-tree-sha1 = "e760a70afdcd461cf01a575947738d359234665c"
-uuid = "66db9d55-30c0-4569-8b51-7e840670fc0c"
-version = "1.0.3"
-
 [[deps.Sockets]]
 uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
 
@@ -711,20 +764,26 @@ uuid = "a2af1166-a08f-5f64-846c-94a0d3cef48c"
 version = "1.1.0"
 
 [[deps.SparseArrays]]
-deps = ["LinearAlgebra", "Random"]
+deps = ["Libdl", "LinearAlgebra", "Random", "Serialization", "SuiteSparse_jll"]
 uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [[deps.SpecialFunctions]]
-deps = ["ChainRulesCore", "IrrationalConstants", "LogExpFunctions", "OpenLibm_jll", "OpenSpecFun_jll"]
-git-tree-sha1 = "d75bda01f8c31ebb72df80a46c88b25d1c79c56d"
+deps = ["IrrationalConstants", "LogExpFunctions", "OpenLibm_jll", "OpenSpecFun_jll"]
+git-tree-sha1 = "ef28127915f4229c971eb43f3fc075dd3fe91880"
 uuid = "276daf66-3868-5448-9aa4-cd146d93841b"
-version = "2.1.7"
+version = "2.2.0"
+
+    [deps.SpecialFunctions.extensions]
+    SpecialFunctionsChainRulesCoreExt = "ChainRulesCore"
+
+    [deps.SpecialFunctions.weakdeps]
+    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 
 [[deps.StaticArrays]]
 deps = ["LinearAlgebra", "Random", "StaticArraysCore", "Statistics"]
-git-tree-sha1 = "6954a456979f23d05085727adb17c4551c19ecd1"
+git-tree-sha1 = "832afbae2a45b4ae7e831f86965469a24d1d8a83"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "1.5.12"
+version = "1.5.26"
 
 [[deps.StaticArraysCore]]
 git-tree-sha1 = "6b7ba252635a5eff6a0b0664a41ee140a1c9e72a"
@@ -734,28 +793,34 @@ version = "1.4.0"
 [[deps.Statistics]]
 deps = ["LinearAlgebra", "SparseArrays"]
 uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+version = "1.9.0"
 
 [[deps.StatsAPI]]
 deps = ["LinearAlgebra"]
-git-tree-sha1 = "f9af7f195fb13589dd2e2d57fdb401717d2eb1f6"
+git-tree-sha1 = "45a7769a04a3cf80da1c1c7c60caf932e6f4c9f7"
 uuid = "82ae8749-77ed-4fe6-ae5f-f523153014b0"
-version = "1.5.0"
+version = "1.6.0"
 
 [[deps.StatsBase]]
 deps = ["DataAPI", "DataStructures", "LinearAlgebra", "LogExpFunctions", "Missings", "Printf", "Random", "SortingAlgorithms", "SparseArrays", "Statistics", "StatsAPI"]
-git-tree-sha1 = "d1bf48bfcc554a3761a133fe3a9bb01488e06916"
+git-tree-sha1 = "75ebe04c5bed70b91614d684259b661c9e6274a4"
 uuid = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
-version = "0.33.21"
+version = "0.34.0"
+
+[[deps.SuiteSparse_jll]]
+deps = ["Artifacts", "Libdl", "Pkg", "libblastrampoline_jll"]
+uuid = "bea87d4a-7f5b-5778-9afe-8cc45184846c"
+version = "5.10.1+6"
 
 [[deps.TOML]]
 deps = ["Dates"]
 uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
-version = "1.0.0"
+version = "1.0.3"
 
 [[deps.Tar]]
 deps = ["ArgTools", "SHA"]
 uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
-version = "1.10.1"
+version = "1.10.0"
 
 [[deps.TensorCore]]
 deps = ["LinearAlgebra"]
@@ -764,10 +829,10 @@ uuid = "62fd8b95-f654-4bbd-a8a5-9c27f68ccd50"
 version = "0.1.1"
 
 [[deps.Tensors]]
-deps = ["ForwardDiff", "LinearAlgebra", "SIMD", "StaticArrays", "Statistics"]
-git-tree-sha1 = "9e6bc81257187256cf53e7d0fd12d5f0716bf50f"
+deps = ["ForwardDiff", "LinearAlgebra", "PrecompileTools", "SIMD", "StaticArrays", "Statistics"]
+git-tree-sha1 = "f6cb7a764c8afca494a27d74430c9b3eb40ce2b8"
 uuid = "48a634ad-e948-5137-8d70-aa71f2a747f4"
-version = "1.11.1"
+version = "1.14.0"
 
 [[deps.Test]]
 deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
@@ -775,14 +840,14 @@ uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [[deps.TranscodingStreams]]
 deps = ["Random", "Test"]
-git-tree-sha1 = "94f38103c984f89cf77c402f2a68dbd870f8165f"
+git-tree-sha1 = "9a6ae7ed916312b41236fcef7e0af564ef934769"
 uuid = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
-version = "0.9.11"
+version = "0.9.13"
 
 [[deps.URIs]]
-git-tree-sha1 = "ac00576f90d8a259f2c9d823e91d1de3fd44d348"
+git-tree-sha1 = "074f993b0ca030848b897beff716d93aca60f06a"
 uuid = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
-version = "1.4.1"
+version = "1.4.2"
 
 [[deps.UUIDs]]
 deps = ["Random", "SHA"]
@@ -797,10 +862,33 @@ git-tree-sha1 = "53915e50200959667e78a92a418594b428dffddf"
 uuid = "1cfade01-22cf-5700-b092-accc4b62d6e1"
 version = "0.4.1"
 
+[[deps.Unitful]]
+deps = ["ConstructionBase", "Dates", "LinearAlgebra", "Random"]
+git-tree-sha1 = "ba4aa36b2d5c98d6ed1f149da916b3ba46527b2b"
+uuid = "1986cc42-f94f-5a68-af5c-568840ba703d"
+version = "1.14.0"
+
+    [deps.Unitful.extensions]
+    InverseFunctionsUnitfulExt = "InverseFunctions"
+
+    [deps.Unitful.weakdeps]
+    InverseFunctions = "3587e190-3f89-42d0-90ee-14403ec27112"
+
+[[deps.UnitfulLatexify]]
+deps = ["LaTeXStrings", "Latexify", "Unitful"]
+git-tree-sha1 = "e2d817cc500e960fdbafcf988ac8436ba3208bfd"
+uuid = "45397f5d-5981-4c77-b2b3-fc36d6e9b728"
+version = "1.6.3"
+
 [[deps.Unzip]]
 git-tree-sha1 = "ca0969166a028236229f63514992fc073799bb78"
 uuid = "41fe7b60-77ed-43a1-b4f0-825fd5a5650d"
 version = "0.2.0"
+
+[[deps.VTKBase]]
+git-tree-sha1 = "c2d0db3ef09f1942d08ea455a9e252594be5f3b6"
+uuid = "4004b06d-e244-455f-a6ce-a5f9919cc534"
+version = "1.0.1"
 
 [[deps.Wayland_jll]]
 deps = ["Artifacts", "Expat_jll", "JLLWrappers", "Libdl", "Libffi_jll", "Pkg", "XML2_jll"]
@@ -815,10 +903,10 @@ uuid = "2381bf8a-dfd0-557d-9999-79630e7b1b91"
 version = "1.25.0+0"
 
 [[deps.WriteVTK]]
-deps = ["Base64", "CodecZlib", "FillArrays", "LightXML", "TranscodingStreams"]
-git-tree-sha1 = "f1b5fce1c4849bc49212c5f471284abf11c57eec"
+deps = ["Base64", "CodecZlib", "FillArrays", "LightXML", "TranscodingStreams", "VTKBase"]
+git-tree-sha1 = "7b46936613e41cfe1c6a5897d243ddcab8feabec"
 uuid = "64499a7a-5c06-52f2-abe2-ccb03c286192"
-version = "1.17.0"
+version = "1.18.0"
 
 [[deps.XML2_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Libiconv_jll", "Pkg", "Zlib_jll"]
@@ -961,13 +1049,13 @@ version = "1.4.0+3"
 [[deps.Zlib_jll]]
 deps = ["Libdl"]
 uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
-version = "1.2.12+3"
+version = "1.2.13+0"
 
 [[deps.Zstd_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "e45044cd873ded54b6a5bac0eb5c971392cf1927"
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "49ce682769cd5de6c72dcf1b94ed7790cd08974c"
 uuid = "3161d3a3-bdf6-5164-811a-617609db77b4"
-version = "1.5.2+0"
+version = "1.5.5+0"
 
 [[deps.fzf_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
@@ -988,9 +1076,9 @@ uuid = "0ac62f75-1d6f-5e53-bd7c-93b484bb37c0"
 version = "0.15.1+0"
 
 [[deps.libblastrampoline_jll]]
-deps = ["Artifacts", "Libdl", "OpenBLAS_jll"]
+deps = ["Artifacts", "Libdl"]
 uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"
-version = "5.1.1+0"
+version = "5.8.0+0"
 
 [[deps.libfdk_aac_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -23,7 +23,7 @@ makedocs(;
     ),
     pages=[
         "Home" => "index.md",
-        "Manual" => ["solvers.md",
+        "Manual" => [#"solvers.md",
                      "userfunctions.md",
                      "nlsolvers.md",
                      "timesteppers.md",

--- a/docs/src/linearsolvers.md
+++ b/docs/src/linearsolvers.md
@@ -1,19 +1,18 @@
 # Linear solvers
+```@docs
+BackslashSolver
+```
+
+**`LinearSolve.jl`**
+
+The linear solvers in [`LinearSolve.jl`](https://github.com/SciML/LinearSolve.jl) are available 
+if the `LinearSolve.jl` package is available (implemented via [`Requires.jl`](https://github.com/JuliaPackaging/Requires.jl)).
+This also includes their default solver that is supplied setting the linear solver to `nothing`. 
+Please see `LinearSolve.jl`'s [documentation](https://docs.sciml.ai/LinearSolve/stable/) for different solvers. 
+
+## Custom linear solver
 A linear solver should support the `solve_linear!` function specified below. 
 
 ```@docs
 FESolvers.solve_linear!
 ```
-
-## Implemented Solvers
-
-### BackslashSolver
-```@docs
-BackslashSolver
-```
-
-### `LinearSolve.jl`
-The linear solvers in [`LinearSolve.jl`](https://github.com/SciML/LinearSolve.jl) are available 
-if the `LinearSolve.jl` package is available (implemented via [`Requires.jl`](https://github.com/JuliaPackaging/Requires.jl)).
-This also includes their default solver that is supplied setting the linear solver to `nothing`. 
-Please see `LinearSolve.jl`'s [documentation](https://docs.sciml.ai/LinearSolve/stable/) for their different solvers. 

--- a/docs/src/literate/plasticity.jl
+++ b/docs/src/literate/plasticity.jl
@@ -162,7 +162,7 @@ end;
 # Note that we use `Δu::Nothing` for the case it is not given, to signal no change.
 # This version is called directly after update_to_next_step! before entering 
 # the nonlinear iterations. 
-function FESolvers.update_problem!(p::PlasticityProblem, Δu; kwargs...)
+function FESolvers.update_problem!(p::PlasticityProblem, Δu, _)
     buf = p.buf 
     def = p.def
     if !isnothing(Δu)

--- a/docs/src/literate/transient_heat.jl
+++ b/docs/src/literate/transient_heat.jl
@@ -158,14 +158,14 @@ function FESolvers.update_to_next_step!(p::TransientHeat, time)
     apply!(FESolvers.getunknowns(p), p.def.ch)
 end
 
-function FESolvers.update_problem!(p::TransientHeat, Δu; update_jacobian, update_residual)
+function FESolvers.update_problem!(p::TransientHeat, Δu, update_spec)
     if !isnothing(Δu)
         apply_zero!(Δu, p.def.ch)
         p.buf.u .+= Δu
     end
     ## Since the problem is linear, we can save some computations by only updating once per time step 
     ## and not after updating the temperatures to check that it has converged. 
-    if update_jacobian || update_residual
+    if FESolvers.should_update_jacobian(update_spec) || FESolvers.should_update_residual(update_spec)
         Δt = p.buf.times[2]-p.buf.times[1]
         doassemble!(p.buf.K, p.buf.r, p.def.cv, p.def.dh, FESolvers.getunknowns(p), p.buf.uold, Δt)
         apply_zero!(FESolvers.getjacobian(p), FESolvers.getresidual(p), p.def.ch)

--- a/docs/src/nlsolvers.md
+++ b/docs/src/nlsolvers.md
@@ -1,40 +1,73 @@
 # Nonlinear solvers
-A nonlinear solver should support the `solve_nonlinear!` function specified below. 
+```@docs
+NewtonSolver
+AdaptiveNewtonSolver
+SteepestDescent
+LinearProblemSolver
+```
 
+## Problem update specification
+An `UpdateSpec`, which can be querried for information,
+is passed to [`update_problem!`](@ref) to give instructions on 
+how to update the problem. 
+```@docs
+FESolvers.UpdateSpec
+```
+
+## Custom solvers
+A custom nonlinear solver can be written by tapping into the existing functions 
+at different levels. For example, `LinearProblemSolver` defines a custom 
+[`solve_nonlinear!`](@ref) that uses the default [`calculate_update!`](@ref). 
+
+All nonlinear solvers are expected to implement the following methods,
+```@docs
+FESolvers.getmaxiter
+FESolvers.getnumiter
+FESolvers.get_convergence_measures
+FESolvers.gettolerance
+FESolvers.get_initial_update_spec
+```
+
+After implementing these, one can either implement `solve_nonlinear!`,
+or a set of method described below to use the default implementation.
 ```@docs
 FESolvers.solve_nonlinear!
 ```
 
-It can do so, by supporting the following functions
+### Methods required by `solve_nonlinear!`
+To use the default implementation of `solve_nonlinear!`,
+[`FESolvers.calculate_update!`](@ref) and the other methods in the
+list below must be implemented for the specific nonlinear solver. 
+The default implementation of `calculate_update!` may be used as well,
+see the description below.
 ```@docs
 FESolvers.calculate_update!
-FESolvers.getmaxiter
-FESolvers.gettolerance
-```
-and optionally
-```@docs
 FESolvers.update_state!
 FESolvers.reset_state!
+FESolvers.get_first_update_spec
+FESolvers.get_update_spec
+FESolvers.maybe_reset_problem!
 ```
 
-The implemented solvers additionally support 
+### Methods required by `calculate_update!`
+To support the default `calculate_update!` implementation, 
+the following methods must be implemented for the given solver. 
 ```@docs
-FESolvers.getnumiter
-FESolvers.getlinesearch
+FESolvers.get_linear_solver
+FESolvers.get_linesearch
 ```
 
-## Implemented Solvers
 
-```@docs
-LinearProblemSolver
-NewtonSolver
-SteepestDescent
-```
-
-### Linesearch
+# Linesearch
 Some nonlinear solvers can use linesearch as a complement, 
 and the following linesearches are included. 
 ```@docs
 NoLineSearch
 ArmijoGoldstein
+```
+
+## Custom linesearch
+A custom linesearch should implement the following function
+```@docs
+linesearch!
 ```

--- a/docs/src/nlsolvers.md
+++ b/docs/src/nlsolvers.md
@@ -1,14 +1,29 @@
 # Nonlinear solvers
 ```@docs
 NewtonSolver
-AdaptiveNewtonSolver
+FESolvers.AdaptiveNewtonSolver
 SteepestDescent
 LinearProblemSolver
 ```
 
+## Further details on selected solvers
+### AdaptiveNewtonSolver
+For the adaptive newton solver, a few basic switchers have been implemented.
+```@docs
+FESolvers.NumIterSwitch
+FESolvers.ToleranceSwitch
+FESolvers.IncreaseSwitch
+```
+
+To implement a custom switcher for `AdaptiveNewtonSolver`, define a new struct
+and the function `switch_information` for that struct:
+```@docs
+FESolvers.switch_information
+```
+
 ## Problem update specification
 An `UpdateSpec`, which can be querried for information,
-is passed to [`update_problem!`](@ref) to give instructions on 
+is passed to [`update_problem!`](@ref FESolvers.update_problem!) to give instructions on 
 how to update the problem. 
 ```@docs
 FESolvers.UpdateSpec
@@ -17,7 +32,8 @@ FESolvers.UpdateSpec
 ## Custom solvers
 A custom nonlinear solver can be written by tapping into the existing functions 
 at different levels. For example, `LinearProblemSolver` defines a custom 
-[`solve_nonlinear!`](@ref) that uses the default [`calculate_update!`](@ref). 
+[`solve_nonlinear!`](@ref FESolvers.solve_nonlinear!) that uses the 
+default [`calculate_update!`](@ref FESolvers.calculate_update!).
 
 All nonlinear solvers are expected to implement the following methods,
 ```@docs
@@ -36,7 +52,7 @@ FESolvers.solve_nonlinear!
 
 ### Methods required by `solve_nonlinear!`
 To use the default implementation of `solve_nonlinear!`,
-[`FESolvers.calculate_update!`](@ref) and the other methods in the
+[`calculate_update!`](@ref FESolvers.calculate_update!) and the other methods in the
 list below must be implemented for the specific nonlinear solver. 
 The default implementation of `calculate_update!` may be used as well,
 see the description below.
@@ -57,6 +73,10 @@ FESolvers.get_linear_solver
 FESolvers.get_linesearch
 ```
 
+### Additional methods that usually don't require specialization
+```@docs
+FESolvers.do_initial_update
+```
 
 # Linesearch
 Some nonlinear solvers can use linesearch as a complement, 
@@ -69,5 +89,5 @@ ArmijoGoldstein
 ## Custom linesearch
 A custom linesearch should implement the following function
 ```@docs
-linesearch!
+FESolvers.linesearch!
 ```

--- a/docs/src/solvers.md
+++ b/docs/src/solvers.md
@@ -1,4 +1,6 @@
 # Solvers
+**NOTE: THIS PAGE IS NOT IN USE, BUT SHOULD BE POPULATED IF MORE SOLVERS ARE IMPLEMENTED**
+
 Solvers are the top level object in this package, 
 each solver should define the function 
 ```@docs

--- a/docs/src/timesteppers.md
+++ b/docs/src/timesteppers.md
@@ -1,15 +1,16 @@
 # Time steppers
+The following time steppers are implemented in FESolvers.
+
+```@docs
+FixedTimeStepper
+AdaptiveTimeStepper
+```
+
+## Custom time stepper
 A time stepper should support the following functions
 
 ```@docs
 FESolvers.initial_time
 FESolvers.islaststep
 FESolvers.update_time
-```
-
-## Implemented steppers
-
-```@docs
-FixedTimeStepper
-AdaptiveTimeStepper
 ```

--- a/docs/src/userfunctions.md
+++ b/docs/src/userfunctions.md
@@ -18,7 +18,6 @@ FESolvers.postprocess!
 FESolvers.close_problem
 ```
 
-
 ## Simple API
 ```@docs
 FESolvers.calculate_convergence_measure

--- a/src/FESolvers.jl
+++ b/src/FESolvers.jl
@@ -19,7 +19,13 @@ abstract type FESolver end
 include("problem.jl")
 include("linearsolvers.jl")
 include("linesearchers.jl")
+
 include("nlsolvers.jl")
+include("nlsolvers/Newton.jl")
+include("nlsolvers/SteepestDescent.jl")
+include("nlsolvers/AdaptiveNewton.jl")
+include("nlsolvers/LinearProblemSolver.jl")
+
 include("timesteppers.jl")
 include("QuasiStaticSolver.jl")
 

--- a/src/FESolvers.jl
+++ b/src/FESolvers.jl
@@ -38,7 +38,13 @@ Solve a given user `problem` using the chosen `solver`
 For details on the functions that should be defined for `problem`,
 see [User problem](@ref)
 """
-function solve_problem! end
+function solve_problem!(problem, solver)
+    try
+        _solve_problem!(problem, solver)
+    finally
+        close_problem(problem)
+    end
+end
 
 function __init__()
     @require(

--- a/src/FESolvers.jl
+++ b/src/FESolvers.jl
@@ -1,4 +1,5 @@
 module FESolvers
+import Base: @kwdef # To support julia < 1.9
 import LinearAlgebra
 using Requires
 export solve_problem!

--- a/src/QuasiStaticSolver.jl
+++ b/src/QuasiStaticSolver.jl
@@ -14,23 +14,6 @@ QuasiStaticSolver(;nlsolver, timestepper) = QuasiStaticSolver(nlsolver, timestep
 getnlsolver(s::QuasiStaticSolver) = s.nlsolver
 gettimestepper(s::QuasiStaticSolver) = s.timestepper
 
-"""
-    solve_problem!(problem, solver)
-
-Solve a time-dependent problem `r(x(t),t)=0` for `x(t)`, 
-stepping throught the time `t`, using the `solver`.
-
-For details on the functions that should be defined for `problem`,
-see [User problem](@ref)
-"""
-function solve_problem!(problem, solver)
-    try
-        _solve_problem!(problem, solver)
-    finally
-        close_problem(problem)
-    end
-end
-
 function _solve_problem!(problem, solver::QuasiStaticSolver)
     # Setup 
     nlsolver = getnlsolver(solver)

--- a/src/linesearchers.jl
+++ b/src/linesearchers.jl
@@ -1,6 +1,21 @@
 abstract type AbstractLineSearch end
-"Singleton that does not perform a linesearch when used in a nonlinear solver"
+
+"""
+    linesearch!(Δx, problem, ls::AbstractLineSearch)
+
+Search along `Δx` to find the minimum of the potential. 
+Return the modified `Δx`.
+"""
+function linesearch! end
+
+"""
+    NoLineSearch()
+
+Singleton that does not perform a linesearch when used in a nonlinear solver
+"""
 struct NoLineSearch <: AbstractLineSearch end
+
+linesearch!(_, _, ::NoLineSearch) = nothing
 
 @doc raw"""
     Armijo-Goldstein{T}(;β=0.9,μ=0.01,τ0=1.0,τmin=1e-4)
@@ -10,7 +25,7 @@ Backtracking line search based on the Armijo-Goldstein condition
 \Pi(\boldsymbol{u} + \tau \Delta\boldsymbol{u}) \leq \Pi(\boldsymbol{u}) - \mu\tau\delta\Pi(\boldsymbol{u})[\Delta \boldsymbol{u}]
 ```
 
-where \$\Pi\$ is the potential, \$\tau\$ the stepsize, and \$\delta\Pi\$ the residuum.
+where ``\Pi`` is the potential, ``\tau`` the stepsize, and ``\delta\Pi`` the residuum.
 
 #Fields
 - `β::T = 0.9` constant factor that changes the steplength τ in each iteration
@@ -25,8 +40,6 @@ Base.@kwdef struct ArmijoGoldstein{T} <: AbstractLineSearch
     τmin::T = 1e-5
 end
 
-linesearch!(searchdirection, problem, ls::NoLineSearch) = nothing
-
 function linesearch!(searchdirection, problem, ls::ArmijoGoldstein)
     τ = ls.τ0; μ = ls.μ; β = ls.β
     𝐮 = getunknowns(problem)
@@ -34,7 +47,6 @@ function linesearch!(searchdirection, problem, ls::ArmijoGoldstein)
     δΠ₀ = getresidual(problem)
     Πₐ = calculate_energy(problem,𝐮 .+ τ .* searchdirection)
     armijo = Πₐ - Π₀ - μ * τ * δΠ₀'searchdirection
-    
     while armijo > 0 && !isapprox(armijo,0.0,atol=1e-8)
         τ *= β
         Πₐ = calculate_energy(problem,𝐮 .+ τ .* searchdirection)

--- a/src/nlsolvers.jl
+++ b/src/nlsolvers.jl
@@ -1,21 +1,37 @@
 """
-    solve_nonlinear!(problem, nlsolver, last_converged)
+    UpdateSpec(;jacobian, residual, type=nothing)
 
-Solve the current time step in the nonlinear `problem`, (`r(x) = 0`),
-by using the nonlinear solver `nlsolver`. `last_converged::Bool` 
-is just for information if the last time step converged or not. 
-In many cases it suffices to overload [`calculate_update!`](@ref) 
-for a custom nonlinear solver. 
-"""
-function solve_nonlinear! end
+An `UpdateSpec` is sent to `update_problem!` to pass the problem
+information about how it should be updated. The following methods 
+should be used by the problem to request information
 
+* `should_update_jacobian(::UpdateSpec)::Bool`: Self explanatory
+* `should_update_residual(::UpdateSpec)::Bool`: Self explanatory
+* `get_update_type(::UpdateSpec)`: How should the problem be updated?
+  This is used by special solvers where, for example, different 
+  approximations of the stiffness is available, see e.g. 
+  [`AdaptiveNewtonSolver`](@ref)
 """
-    function calculate_update!(Δx, problem, nlsolver, iter)
+struct UpdateSpec{JT}
+    jacobian::Bool      # Should the jacobian be updated?
+    residual::Bool      # Should the residual be updated?
+    type::JT            # What type of update should be performed?
+end
+function UpdateSpec(;jacobian, residual, type=nothing)
+    return UpdateSpec(jacobian, residual, type)
+end
+should_update_jacobian(us::UpdateSpec) = us.jacobian
+should_update_residual(us::UpdateSpec) = us.residual
+get_update_type(us::UpdateSpec) = us.type
 
-According to the nonlinear solver, `nlsolver`, at iteration `iter`,
-calculate the update, `Δx` to the unknowns `x`.
-"""
-function calculate_update! end
+# Temporary solution to support old interface
+# TODO: Remove after some time...
+function update_problem!(problem, Δx, update_spec#=::UpdateSpec=#)
+    return update_problem!(problem, Δx; 
+        update_jacobian = should_update_jacobian(update_spec), 
+        update_residual = should_update_residual(update_spec)
+        )
+end
 
 """
     getmaxiter(nlsolver)
@@ -32,6 +48,15 @@ Returns the last number of iterations used by the nonlinear solver
 function getnumiter end
 
 """
+    get_convergence_measures(nlsolver[, i])
+
+Get the convergence measures for iteration `i` from the nlsolver. 
+If `i` is not given, the full history is returned. 
+Note that unless `i::Int` is given, a new vector will be allocated.
+"""
+function get_convergence_measures end
+
+"""
     gettolerance(nlsolver)
 
 Returns the iteration tolerance for the solver
@@ -39,229 +64,123 @@ Returns the iteration tolerance for the solver
 function gettolerance end
 
 """
-    update_state!(nlsolver, r)
+    update_state!(nlsolver, problem, r)
 
 A nonlinear solver may solve information about its convergence state.
 `r` is the output from [`calculate_convergence_measure`](@ref) when 
 this function is called by the default implementation of 
 [`check_convergence_criteria`](@ref). 
-`update_state!` is optional to implement
 """
-update_state!(::Any, _) = nothing
+update_state!(_, _, _) = nothing
 
 """
     reset_state!(nlsolver)
 
-If [`update_state!`](@ref) is implemented, this function is used to 
-reset its state at the beginning of each new time step. 
+This function is used to reset `nlsolver`'s state at the 
+beginning of each new time step. 
 """
 reset_state!(::Any) = nothing
 
 """
-    update_jac_initial(nlsolver)
+    get_initial_update_spec(nlsolver)::UpdateSpec
 
-Should the jacobian be updated before starting to solve the problem?
-Defaults to `false` if not implemented
+How to update initially (before starting time stepping)
 """
-update_jac_initial(::Any) = false
-
-"""
-    update_jac_first(nlsolver)
-
-Should the jacobian be updated before the first iteration of each time step?
-Defaults to `true` if not implemented
-"""
-update_jac_first(::Any) = true
+function get_initial_update_spec end
 
 """
-    update_jac_each(nlsolver)
+    do_initial_update(nlsolver)
 
-Should the jacobian be updated after each iteration?
-Defaults to `true` if not implemented
+Should the problem be updated initially, before starting time stepping?
+Normally, not required to overload as the update specification from 
+`get_initial_update_spec` is used to decide how if an update is required. 
 """
-update_jac_each(::Any) = true
-
-"""
-    NewtonSolver(;
-        linsolver=BackslashSolver(), linesearch=NoLineSearch(), 
-        maxiter=10, tolerance=1.e-6,
-        update_jac_first=true, update_jac_each=true)
-
-Use the standard Newton-Raphson solver to solve the nonlinear 
-problem r(x) = 0 with `tolerance` within the maximum number 
-of iterations `maxiter`. 
-
-## Quasi-Newton methods
-**Linesearch:** The `linsolver` argument determines the used linear solver
-whereas the `linesearch` can be set currently between `NoLineSearch` or
-`ArmijoGoldstein`. The latter globalizes the Newton strategy.
-
-**Jacobian updates: **
-The keyword `update_jac_first` decides if the jacobian from the previously converged
-time step should be updated after calling `update_to_next_step!`, or to use the old. 
-Setting `update_jac_each` implies that the jacobian will not be updated during the iterations.
-If both `update_jac_each` and `update_jac_first` are false, the initial jacobian will be used 
-throughout. Note that these keywords require that the problem respects the `update_jacobian`
-keyword given to `update_problem!`.
-For time-independent problems or time-depdent problems with 
-constant time steps, `update_jac_first=false` is often a good choice. 
-However, for time-dependent problems with changing time step length, 
-the standard solver (default), may work better. 
-"""
-mutable struct NewtonSolver{LS,LSearch,T}
-    const linsolver::LS
-    const linesearch::LSearch
-    const maxiter::Int
-    const tolerance::T
-    const update_jac_first::Bool # Should jacobian be updated first iteration
-    const update_jac_each::Bool  # Should jacobian be updated each iteration
-    numiter::Int                # Last step number of iterations
-    const residuals::Vector{T}  # Last step residual history
+function do_initial_update(nlsolver)
+    us = get_initial_update_spec(nlsolver)
+    return should_update_jacobian(us) || should_update_residual(us)
 end
 
-function NewtonSolver(;
-        linsolver=BackslashSolver(), linesearch=NoLineSearch(), 
-        maxiter=10, tolerance=1.e-6,
-        update_jac_first=true, update_jac_each=true
-    )
-    residuals = zeros(typeof(tolerance), maxiter+1)
-    return NewtonSolver(
-        linsolver, linesearch, 
-        maxiter, tolerance, 
-        update_jac_first, update_jac_each, 
-        0, residuals
-        )
-end
-getsystemmatrix(problem, ::NewtonSolver) = getjacobian(problem)
-
-update_jac_initial(nlsolver::NewtonSolver) = !(nlsolver.update_jac_first) 
-update_jac_first(nlsolver::NewtonSolver) = nlsolver.update_jac_first
-update_jac_each(nlsolver::NewtonSolver) = nlsolver.update_jac_each
-
-@doc raw"""
-    SteepestDescent(;maxiter=10, tolerance=1.e-6)
-
-Use a steepest descent solver to solve the nonlinear 
-problem r(x) = 0, which minimizes a potential \Pi with `tolerance`
-and the maximum number of iterations `maxiter`.
-
-This method is second derivative free and is not as locally limited as a Newton-Raphson scheme.
-Thus, it is especially suited for strongly nonlinear behavior with potentially vanishing tangent stiffnesses.
-For this method, it is required to implement [`getdescentpreconditioner`](@ref) or alternatively
-[`getsystemmatrix`](@ref) with `SteepestDescent`. 
 """
-Base.@kwdef mutable struct SteepestDescent{LineSearch,LinearSolver,T}
-    const linsolver::LinearSolver = BackslashSolver()
-    const linesearch::LineSearch = ArmijoGoldstein()
-    const maxiter::Int = 200
-    const tolerance::T = 1e-6
-    numiter::Int = 0  # Last step number of iterations
-    const residuals::Vector{T} = zeros(typeof(tolerance),maxiter+1)  # Last step residual history
-end
-getsystemmatrix(problem, ::SteepestDescent) = getdescentpreconditioner(problem)
-update_jac_initial(::SteepestDescent) = false
-update_jac_first(::SteepestDescent) = false
-update_jac_each(::SteepestDescent) = false
+    get_first_update_spec(nlsolver, last_converged::Bool)
+
+Get the update specification for `nlsolver` in the first iteration of the time step.
+`last_converged` indicates if the previous time step converged, or if this is a retry 
+using, e.g., a different time step. 
+"""
+function get_first_update_spec end
 
 """
-    getlinesearch(nlsolver)
+    get_update_spec(nlsolver)::UpdateSpec
+
+Get the update specification during regular iterations. It is the `nlsolver`'s job 
+to keep track of any state required for deciding changes to the update specification 
+during iterations. 
+"""
+function get_update_spec end
+
+# Optional methods 
+"""
+    get_linesearch(nlsolver)
 Returns the used linesearch of the nonlinear solver.
 """
-getlinesearch(nlsolver::Union{NewtonSolver,SteepestDescent}) = nlsolver.linesearch
+function get_linesearch end 
 
-getmaxiter(nlsolver::Union{NewtonSolver,SteepestDescent}) = nlsolver.maxiter
-gettolerance(nlsolver::Union{NewtonSolver,SteepestDescent}) = nlsolver.tolerance
-getnumiter(s::Union{NewtonSolver,SteepestDescent}) = s.numiter
+"""
+    get_linear_solver(nlsolver)
 
+Get the linear solver used by the nonlinear solver
+"""
+function get_linear_solver end
 
-function reset_state!(s::Union{NewtonSolver,SteepestDescent})
-    s.numiter = 0
-    fill!(s.residuals, 0)
-end
+"""
+    solve_nonlinear!(problem, nlsolver, last_converged)
 
-function update_state!(s::Union{NewtonSolver,SteepestDescent}, r)
-    s.numiter += 1
-    s.residuals[s.numiter] = r 
-end
-
+Solve the current time step in the nonlinear `problem`, (`r(x) = 0`),
+by using the nonlinear solver `nlsolver`. `last_converged::Bool` 
+is just for information if the last time step converged or not. 
+In many cases it suffices to overload [`calculate_update!`](@ref) 
+for a custom nonlinear solver. 
+"""
 function solve_nonlinear!(problem, nlsolver, last_converged)
     maxiter = getmaxiter(nlsolver)
     reset_state!(nlsolver)
-
-    if last_converged || update_jac_first(nlsolver)
-        update_problem!(problem, nothing; update_residual=true, update_jacobian=update_jac_first(nlsolver))
-    elseif update_jac_each(nlsolver) # If last step didn't converge and we updated the jacobian for each of those iterations, 
-         # we have no option than to update the jacobian to the new value
-        update_problem!(problem, nothing; update_residual=true, update_jacobian=true)
-    else # In this case, !update_jac_each(nlsolver) && !update_jac_first(nlsolver)
-        update_problem!(problem, nothing; update_residual=true, update_jacobian=false)
-    end
-
+    update_problem!(problem, nothing, get_first_update_spec(nlsolver, last_converged))
     Δa = zero(getunknowns(problem))
     for iter in 1:maxiter
         check_convergence_criteria(problem, nlsolver, Δa, iter) && return true
-        calculate_update!(Δa, problem, nlsolver, iter)
-        update_problem!(problem, Δa; update_residual=true, update_jacobian=update_jac_each(nlsolver))
+        
+        maybe_reset_problem!(problem, Δa, nlsolver) # No-op for standard nlsolver, but can be customized
+        
+        calculate_update!(Δa, problem, nlsolver)          # Newton's method: Δa .= -K\r 
+        update_problem!(problem, Δa, get_update_spec(nlsolver)) # a += Δa and update K and r according to update_spec
     end
     check_convergence_criteria(problem, nlsolver, Δa, maxiter+1) && return true
     return false
 end
 
-function calculate_update!(Δa, problem, nlsolver::Union{SteepestDescent,NewtonSolver}, iter)
+"""
+    function calculate_update!(Δx, problem, nlsolver)
+
+According to the nonlinear solver, `nlsolver`, at iteration `iter`,
+calculate the update, `Δx` to the unknowns `x`.
+"""
+function calculate_update!(Δa, problem, nlsolver)
     r = getresidual(problem)
-    K = getsystemmatrix(problem,nlsolver)
-    solve_linear!(Δa, K, r, nlsolver.linsolver)
-    linesearch!(Δa, problem, getlinesearch(nlsolver)) # Scale Δa
+    K = getsystemmatrix(problem, nlsolver)
+    solve_linear!(Δa, K, r, get_linear_solver(nlsolver))
+    linesearch!(Δa, problem, get_linesearch(nlsolver)) # Scale Δa
     return Δa
 end
 
 """
-    LinearProblemSolver(;linsolver=BackslashSolver())
+    maybe_reset_problem!(problem, Δa_old, nlsolver)
 
-This is a special type of "Nonlinear solver", which actually only solves linear problems, 
-but allows all other features (i.e. time stepping and postprocessing) of the `FESolvers` 
-package to be used. In particular, it allows you to maintain all other parts of your problem 
-exactly the same as for a nonlinear problem, but it is possible to get better performance as 
-it is, in principle, not necessary to assemble twice in each time step. 
+*Note:* Custom nonlinear solvers may rely on the no-op default implementation.
 
-This solver is specialized for linear problems of the form
-```math
-\\boldsymbol{r}(\\boldsymbol{x}(t),t)=\\boldsymbol{K}(t) \\boldsymbol{x}(t) - \\boldsymbol{f}(t)
-```
-where ``\\boldsymbol{K}=\\partial \\boldsymbol{r}/\\partial \\boldsymbol{x}``. 
-It expects that ``\\boldsymbol{x}(t)`` and ``\\boldsymbol{r}(t)`` have been updated to 
-``\\boldsymbol{x}_\\mathrm{bc}`` and ``\\boldsymbol{r}_\\mathrm{bc}=\\boldsymbol{K}(t)\\boldsymbol{x}_\\mathrm{bc}-\\boldsymbol{f}(t)``,
-such that 
-```math
-\\boldsymbol{x}(t) = \\boldsymbol{x}_\\mathrm{bc} - \\boldsymbol{K}^{-1}(t)\\boldsymbol{r}_\\mathrm{bc}
-= \\boldsymbol{x}_\\mathrm{bc} - \\boldsymbol{K}^{-1}(t)\\left[\\boldsymbol{K}(t)\\boldsymbol{x}_\\mathrm{bc}-\\boldsymbol{f}(t)\\right]
-= \\boldsymbol{K}^{-1}(t)\\boldsymbol{f}(t)
-```
-is the solution to the current time step. This normally implies when using Ferrite the same procedure as for nonlinear problems, i.e. 
-that the boundary conditions are applied in `update_to_next_step!` and `update_problem!`, as well as the calculation of the residual 
-according to above and that `apply_zero!(K,r,ch)` is called (on both the residual and the stiffness matrix).
-
-If you have strange results when running the `LinearProblemSolver`, 
-please ensure that the problem converges in one iteration for the [`NewtonSolver`](@ref)
+After checking for convergence, the default implementation of `solve_nonlinear`
+will call this function, allowing the nlsolver to call `update_problem!(problem, -Δa)`
+to reset the problem to the state at the last iteration (this is useful if e.g. the 
+jacobian should be calculated differently, or if a higher dampening factor should be 
+used when calculating the update).
 """
-struct LinearProblemSolver{LinearSolver}
-    linsolver::LinearSolver
-end
-LinearProblemSolver(;linsolver=BackslashSolver()) = LinearProblemSolver(linsolver)
-
-getsystemmatrix(problem, ::LinearProblemSolver) = getjacobian(problem)
-
-# Support this just for convenience, it makes it easier when printing status etc. 
-getnumiter(::LinearProblemSolver) = 0
-getmaxiter(::LinearProblemSolver) = 1
-gettolerance(::LinearProblemSolver) = NaN
-
-function solve_nonlinear!(problem, nlsolver::LinearProblemSolver, last_converged)
-    update_problem!(problem, nothing; update_residual=true, update_jacobian=true)
-    r = getresidual(problem)
-    K = getsystemmatrix(problem,nlsolver)
-    Δa = similar(getunknowns(problem))
-    solve_linear!(Δa, K, r, nlsolver.linsolver)
-    update_problem!(problem, Δa; update_residual=false, update_jacobian=false)
-    return true # Assume always converged
-end
+maybe_reset_problem!(problem, Δa, nlsolver) = nothing 

--- a/src/nlsolvers/AdaptiveNewton.jl
+++ b/src/nlsolvers/AdaptiveNewton.jl
@@ -1,3 +1,16 @@
+"""
+    AdaptiveNewtonSolver(;
+        update_types, switch_criterion,
+        linsolver=BackslashSolver(), linesearch=NoLineSearch(),
+        maxiter=10, tolerance=1e-6, update_jac_first=true)
+
+Define an adaptive newton solver, where the update type 
+(given to [`UpdateSpec`](@ref FESolvers.UpdateSpec))
+changes during the iterations. The different options 
+are given to `update_types`, and the criterion to switch 
+between them is given to `switch_criterion`. Remaining options
+are similar to the standard newton solver. 
+"""
 Base.@kwdef mutable struct AdaptiveNewtonSolver{LinearSolver,LineSearch,T,UT,SC}
     const linsolver::LinearSolver = BackslashSolver()
     const linesearch::LineSearch = NoLineSearch()
@@ -59,6 +72,17 @@ function maybe_reset_problem!(problem, Δa, s::AdaptiveNewtonSolver)
         update_problem!(problem, Δa, get_update_spec(s))
     end
 end
+
+"""
+    switch_information(switch_criterion, nlsolver)
+
+Create a custom `switch_criterion` by overloading this function,
+which given the defined `switch_criterion` and the `nlsolver`,
+should return `reset_problem::Bool` and `new_nr::Int`, which 
+determines if the problem should be reset to the state before its 
+last update and which update_type should be used next, respectively.
+"""
+function switch_information end
 
 # Implemented switches
 """

--- a/src/nlsolvers/AdaptiveNewton.jl
+++ b/src/nlsolvers/AdaptiveNewton.jl
@@ -33,8 +33,8 @@ end
 function get_first_update_spec(nls::AdaptiveNewtonSolver, last_converged::Bool)
     if last_converged
         return UpdateSpec(jacobian=nls.update_jac_first, residual=true, type=_get_update_type(nls))
-    else # We must update if jacobian was updated for each
-        return UpdateSpec(jacobian=nls.update_jac_each, residual=true, type=_get_update_type(nls))
+    else # We must update since jacobian when it didn't converge
+        return UpdateSpec(jacobian=true, residual=true, type=_get_update_type(nls))
     end
 end
 function get_update_spec(nls::AdaptiveNewtonSolver)

--- a/src/nlsolvers/AdaptiveNewton.jl
+++ b/src/nlsolvers/AdaptiveNewton.jl
@@ -1,0 +1,128 @@
+Base.@kwdef mutable struct AdaptiveNewtonSolver{LinearSolver,LineSearch,T,UT,SC}
+    const linsolver::LinearSolver = BackslashSolver()
+    const linesearch::LineSearch = NoLineSearch()
+    const maxiter::Int = 10
+    const tolerance::T = 1e-6
+    const update_jac_first::Bool=true # Should jacobian be updated first iteration (or use the one from the previous converged)
+    const update_types::UT
+    update_type_nr::Int=1
+    const switch_criterion::SC
+    reset_problem::Bool=false
+    numiter::Int = 0  # Current number of iterations (reset at beginning of new iteration)
+    const residuals::Vector{T} = zeros(typeof(tolerance),maxiter+1)  # Last step residual history
+end
+getsystemmatrix(problem, ::AdaptiveNewtonSolver) = getjacobian(problem)
+
+_get_update_type(nls::AdaptiveNewtonSolver) = nls.update_types[nls.update_type_nr]
+function get_initial_update_spec(nls::AdaptiveNewtonSolver)
+    return UpdateSpec(;jacobian=!(nls.update_jac_first), residual=false, type=_get_update_type(nls))
+end
+function get_first_update_spec(nls::AdaptiveNewtonSolver, last_converged::Bool)
+    if last_converged
+        return UpdateSpec(jacobian=nls.update_jac_first, residual=true, type=_get_update_type(nls))
+    else # We must update if jacobian was updated for each
+        return UpdateSpec(jacobian=nls.update_jac_each, residual=true, type=_get_update_type(nls))
+    end
+end
+function get_update_spec(nls::AdaptiveNewtonSolver)
+    return UpdateSpec(;jacobian=true, residual=true, type=_get_update_type(nls))
+end
+
+get_linesearch(nlsolver::AdaptiveNewtonSolver) = nlsolver.linesearch
+get_linear_solver(nlsolver::AdaptiveNewtonSolver) = nlsolver.linsolver
+
+getmaxiter(nlsolver::AdaptiveNewtonSolver) = nlsolver.maxiter
+gettolerance(nlsolver::AdaptiveNewtonSolver) = nlsolver.tolerance
+getnumiter(s::AdaptiveNewtonSolver) = s.numiter
+get_convergence_measures(s::AdaptiveNewtonSolver, inds=1:getnumiter(s)) = s.residuals[inds]
+
+get_type_number(s::AdaptiveNewtonSolver) = s.update_type_nr
+
+function reset_state!(s::AdaptiveNewtonSolver)
+    s.numiter = 0
+    fill!(s.residuals, 0)
+    s.update_type_nr = 1
+    s.reset_problem = false
+end
+
+function update_state!(s::AdaptiveNewtonSolver, _, r)
+    s.numiter += 1
+    s.residuals[s.numiter] = r
+    if s.numiter > 1
+        s.reset_problem, s.update_type_nr = switch_information(s.switch_criterion, s)
+    end
+end
+
+function maybe_reset_problem!(problem, Δa, s::AdaptiveNewtonSolver)
+    if s.reset_problem
+        map!(-, Δa, Δa)
+        update_problem!(problem, Δa, get_update_spec(s))
+    end
+end
+
+# Implemented switches
+"""
+    NumIterSwitch(;switch_after)
+
+Switch to `update_types[2]` after `switch_after`
+iterations with `update_types[1]`
+"""
+@kwdef struct NumIterSwitch
+    switch_after::Int
+end
+
+function switch_information(crit::NumIterSwitch, nls)
+    numiter = getnumiter(nls)
+    reset_problem = false
+    new_nr = numiter > crit.switch_after ? 2 : 1
+    return reset_problem, new_nr
+end
+
+"""
+    NumIterSwitch(;switch_after)
+
+Use `update_types[1]` when the convergence measure is larger than
+`switch_at`. When the convergence measure is below `switch_at`, 
+use `update_types[2]`. If the convergence measure increases above 
+`switch_at` again, reset the problem and change to `update_types[1]`
+iterations with `update_types[1]`.
+"""
+struct ToleranceSwitch{T}
+    switch_at::T
+end
+function switch_information(crit::ToleranceSwitch, nls)
+    k = getnumiter(nls)
+    r = get_convergence_measures(nls, k)
+    if r > crit.switch_at
+        reset_problem = (get_type_number(nls) == 2)
+        return reset_problem, 1
+    else
+        return false, 2
+    end
+end
+
+"""
+    IncreaseSwitch(;num_slow)
+
+Use the (typically) fast but less stable `update_types[1]` as long 
+as the convergence measure is decreasing. If it starts increasing, 
+switch to the (typically) slower but more stable `update_types[2]`.
+Use this for `num_slow` iterations after the convergence measure 
+starts to decrease again.
+"""
+mutable struct IncreaseSwitch
+    num_slow::Int # How many slow types to do after an increase in error
+    num_at_switch::Int # At what numiter the switch was done
+end
+IncreaseSwitch(;num_slow) = IncreaseSwitch(num_slow, -(num_slow+1))
+function switch_information(crit::IncreaseSwitch, nls)
+    k = getnumiter(nls)
+    Δr = get_convergence_measures(nls, k) - get_convergence_measures(nls, k-1)
+    if Δr < 0 && (crit.num_at_switch+crit.num_slow < k) 
+        return false, 1 # Use primary technique (typically faster, but less stable)
+    else 
+        Δr > 0 && (crit.num_at_switch = k) # Set num_at_switch if residual increasing
+        reset_problem = (get_type_number(nls) == 1)
+        return reset_problem, 2 # Use secondary technique (typically slower, but more stable)
+    end
+end

--- a/src/nlsolvers/LinearProblemSolver.jl
+++ b/src/nlsolvers/LinearProblemSolver.jl
@@ -1,0 +1,64 @@
+"""
+    LinearProblemSolver(;linsolver=BackslashSolver())
+
+This is a special type of "Nonlinear solver", which actually only solves linear problems, 
+but allows all other features (i.e. time stepping and postprocessing) of the `FESolvers` 
+package to be used. In particular, it allows you to maintain all other parts of your problem 
+exactly the same as for a nonlinear problem, but it is possible to get better performance as 
+it is, in principle, not necessary to assemble twice in each time step. 
+
+This solver is specialized for linear problems of the form
+```math
+\\boldsymbol{r}(\\boldsymbol{x}(t),t)=\\boldsymbol{K}(t) \\boldsymbol{x}(t) - \\boldsymbol{f}(t)
+```
+where ``\\boldsymbol{K}=\\partial \\boldsymbol{r}/\\partial \\boldsymbol{x}``. 
+It expects that ``\\boldsymbol{x}(t)`` and ``\\boldsymbol{r}(t)`` have been updated to 
+``\\boldsymbol{x}_\\mathrm{bc}`` and ``\\boldsymbol{r}_\\mathrm{bc}=\\boldsymbol{K}(t)\\boldsymbol{x}_\\mathrm{bc}-\\boldsymbol{f}(t)``,
+such that 
+```math
+\\boldsymbol{x}(t) = \\boldsymbol{x}_\\mathrm{bc} - \\boldsymbol{K}^{-1}(t)\\boldsymbol{r}_\\mathrm{bc}
+= \\boldsymbol{x}_\\mathrm{bc} - \\boldsymbol{K}^{-1}(t)\\left[\\boldsymbol{K}(t)\\boldsymbol{x}_\\mathrm{bc}-\\boldsymbol{f}(t)\\right]
+= \\boldsymbol{K}^{-1}(t)\\boldsymbol{f}(t)
+```
+is the solution to the current time step. This normally implies when using Ferrite the same procedure as for nonlinear problems, i.e. 
+that the boundary conditions are applied in `update_to_next_step!` and `update_problem!`, as well as the calculation of the residual 
+according to above and that `apply_zero!(K,r,ch)` is called (on both the residual and the stiffness matrix).
+
+If you have strange results when running the `LinearProblemSolver`, 
+please ensure that the problem converges in one iteration for the [`NewtonSolver`](@ref)
+"""
+struct LinearProblemSolver{LinearSolver}
+    linsolver::LinearSolver
+end
+LinearProblemSolver(;linsolver=BackslashSolver()) = LinearProblemSolver(linsolver)
+
+get_initial_update_spec(::LinearProblemSolver) = UpdateSpec(jacobian=false, residual=false)
+get_first_update_spec(::LinearProblemSolver, args...) = UpdateSpec(jacobian=true, residual=true)
+get_update_spec(::LinearProblemSolver) = UpdateSpec(jacobian=false, residual=false)
+
+getsystemmatrix(problem, ::LinearProblemSolver) = getjacobian(problem)
+
+get_linesearch(::LinearProblemSolver) = NoLineSearch()
+get_linear_solver(nlsolver::LinearProblemSolver) = nlsolver.linsolver
+
+# Support this just for convenience, it makes it easier when printing status etc. 
+getnumiter(::LinearProblemSolver) = 0
+getmaxiter(::LinearProblemSolver) = 1
+gettolerance(::LinearProblemSolver) = NaN
+get_convergence_measures(s::LinearProblemSolver, i::Number) = NaN
+function get_convergence_measures(s::LinearProblemSolver, inds)
+    checkbounds([NaN, NaN], inds)
+    return [NaN for _ in inds]
+end
+get_convergence_measures(s::LinearProblemSolver) = [NaN,NaN]
+
+
+function solve_nonlinear!(problem, nlsolver::LinearProblemSolver, last_converged)
+    update_problem!(problem, nothing, get_first_update_spec(nlsolver))
+    Δa = similar(getunknowns(problem))
+    
+    calculate_update!(Δa, problem, nlsolver)
+
+    update_problem!(problem, Δa, get_update_spec(nlsolver))
+    return true # Assume always converged
+end

--- a/src/nlsolvers/Newton.jl
+++ b/src/nlsolvers/Newton.jl
@@ -1,0 +1,69 @@
+"""
+    NewtonSolver(;
+        linsolver=BackslashSolver(), linesearch=NoLineSearch(), 
+        maxiter=10, tolerance=1.e-6,
+        update_jac_first=true, update_jac_each=true)
+
+Use the standard Newton-Raphson solver to solve the nonlinear 
+problem r(x) = 0 with `tolerance` within the maximum number 
+of iterations `maxiter`. 
+
+## Quasi-Newton methods
+**Linesearch:** The `linsolver` argument determines the used linear solver
+whereas the `linesearch` can be set currently between `NoLineSearch` or
+`ArmijoGoldstein`. The latter globalizes the Newton strategy.
+
+**Jacobian updates: **
+The keyword `update_jac_first` decides if the jacobian from the previously converged
+time step should be updated after calling `update_to_next_step!`, or to use the old. 
+Setting `update_jac_each` implies that the jacobian will not be updated during the iterations.
+If both `update_jac_each` and `update_jac_first` are false, the initial jacobian will be used 
+throughout. Note that these keywords require that the problem respects the `update_jacobian`
+keyword given to `update_problem!`.
+For time-independent problems or time-depdent problems with 
+constant time steps, `update_jac_first=false` is often a good choice. 
+However, for time-dependent problems with changing time step length, 
+the standard solver (default), may work better. 
+"""
+Base.@kwdef mutable struct NewtonSolver{LinearSolver,LineSearch,T}
+    const linsolver::LinearSolver = BackslashSolver()
+    const linesearch::LineSearch = NoLineSearch()
+    const maxiter::Int = 10
+    const tolerance::T = 1e-6
+    const update_jac_first::Bool=true # Should jacobian be updated first iteration
+    const update_jac_each::Bool=true  # Should jacobian be updated each iteration
+    numiter::Int = 0  # Current number of iterations (reset at beginning of new iteration)
+    const residuals::Vector{T} = zeros(typeof(tolerance),maxiter+1)  # Last step residual history
+end
+getsystemmatrix(problem, ::NewtonSolver) = getjacobian(problem)
+
+get_initial_update_spec(nlsolver::NewtonSolver) = UpdateSpec(jacobian=!(nlsolver.update_jac_first), residual=false)
+function get_first_update_spec(nlsolver::NewtonSolver, last_converged::Bool)
+    if last_converged
+        return UpdateSpec(jacobian=nlsolver.update_jac_first, residual=true)
+    else # We must update if jacobian was updated for each
+        return UpdateSpec(jacobian=nlsolver.update_jac_each, residual=true)
+    end
+end
+function get_update_spec(nlsolver::NewtonSolver)
+    return UpdateSpec(;jacobian=nlsolver.update_jac_each, residual=true)
+end
+
+get_linesearch(nlsolver::NewtonSolver) = nlsolver.linesearch
+get_linear_solver(nlsolver::NewtonSolver) = nlsolver.linsolver
+
+getmaxiter(nlsolver::NewtonSolver) = nlsolver.maxiter
+gettolerance(nlsolver::NewtonSolver) = nlsolver.tolerance
+getnumiter(s::NewtonSolver) = s.numiter
+get_convergence_measures(s::NewtonSolver, inds=1:getnumiter(s)) = s.residuals[inds]
+
+
+function reset_state!(s::NewtonSolver)
+    s.numiter = 0
+    fill!(s.residuals, 0)
+end
+
+function update_state!(s::NewtonSolver, _, r)
+    s.numiter += 1
+    s.residuals[s.numiter] = r 
+end

--- a/src/nlsolvers/SteepestDescent.jl
+++ b/src/nlsolvers/SteepestDescent.jl
@@ -1,0 +1,43 @@
+"""
+    SteepestDescent(;maxiter=10, tolerance=1.e-6)
+
+Use a steepest descent solver to solve the nonlinear 
+problem r(x) = 0, which minimizes a potential ``\\Pi`` with `tolerance`
+and the maximum number of iterations `maxiter`.
+
+This method is second derivative free and is not as locally limited as a Newton-Raphson scheme.
+Thus, it is especially suited for strongly nonlinear behavior with potentially vanishing tangent stiffnesses.
+For this method, it is required to implement [`getdescentpreconditioner`](@ref) or alternatively
+[`getsystemmatrix`](@ref) with `SteepestDescent`. 
+"""
+Base.@kwdef mutable struct SteepestDescent{LineSearch,LinearSolver,T}
+    const linsolver::LinearSolver = BackslashSolver()
+    const linesearch::LineSearch = ArmijoGoldstein()
+    const maxiter::Int = 200
+    const tolerance::T = 1e-6
+    numiter::Int = 0  # Last step number of iterations
+    const residuals::Vector{T} = zeros(typeof(tolerance),maxiter+1)  # Last step residual history
+end
+getsystemmatrix(problem, ::SteepestDescent) = getdescentpreconditioner(problem)
+
+get_initial_update_spec(::SteepestDescent) = UpdateSpec(;jacobian=false, residual=false)
+get_first_update_spec(::SteepestDescent, _) = UpdateSpec(;jacobian=false, residual=true)
+get_update_spec(::SteepestDescent) = UpdateSpec(;jacobian=false, residual=true)
+
+get_linesearch(nlsolver::SteepestDescent) = nlsolver.linesearch
+get_linear_solver(nlsolver::SteepestDescent) = nlsolver.linsolver
+
+getmaxiter(nlsolver::SteepestDescent) = nlsolver.maxiter
+gettolerance(nlsolver::SteepestDescent) = nlsolver.tolerance
+getnumiter(s::SteepestDescent) = s.numiter
+get_convergence_measures(s::SteepestDescent, inds=1:getnumiter(s)) = s.residuals[inds]
+
+function reset_state!(s::SteepestDescent)
+    s.numiter = 0
+    fill!(s.residuals, 0)
+end
+
+function update_state!(s::SteepestDescent, _, r)
+    s.numiter += 1
+    s.residuals[s.numiter] = r 
+end

--- a/src/problem.jl
+++ b/src/problem.jl
@@ -67,30 +67,32 @@ function update_to_next_step! end
 """
     update_problem!(problem, Δx, update_spec::UpdateSpec)
 
-The `update_spec` gives the information about what and how to update.
-See the documentation for [`UpdateSpec`](@ref) for further details. 
-A simplified interface is called by default to perserve backwards compatibility,
-but it is recommended to use the new interface. 
-
-    update_problem!(problem, Δx; update_residual::Bool, update_jacobian::Bool)
-    
-Update the unknowns, `x += Δx`, if `!isnothing(Δx)`, and in any case
-* Assemble the residual if `update_residual=true`
-* Assemble the jacobian if `update_jacobian=true`
-
-Note that one can also update the residual and jacobian if any of the kwargs 
-are false, the kwargs just states if an update is required. 
-A simple function overload that doesn't account for the kwargs is
-```julia
-FESolvers.update_problem!(problem, Δx; kwargs...)
-```
-
+Update the unknowns of the problem by `Δx` according to `update_spec`.
+Note that 
 - Some linear solvers may be inaccurate, and if a modified stiffness is used 
   to enforce constraints on `x`, it is good the force `Δx=0` on these
   components inside this function. 
 - `Δx=nothing` in the first call after [`update_to_next_step!`](@ref)
   in which case, typically, no change of `x` should be made. Dirichlet
   boundary conditions are typically updated in `update_to_next_step!`.
+
+The `update_spec` gives the information about what and how to update.
+See the documentation for [`UpdateSpec`](@ref) for further details. 
+This feature is used by some nonlinear solvers to customize the iteration 
+strategy to speed up or aid convergence. For basic cases when getting started, 
+this can be ignored and a simple function definition would be 
+```julia
+FESolvers.update_problem!(problem, Δx, _)
+```
+
+    update_problem!(problem, Δx; update_residual::Bool, update_jacobian::Bool)
+
+The old but now deprecated interface is still available without `update_spec`.
+The instructions are here:
+
+* Assemble the residual if `update_residual=true`
+* Assemble the jacobian if `update_jacobian=true`
+
 """
 function update_problem! end
 
@@ -105,7 +107,6 @@ where `ch::Ferrite.ConstraintHandler`. `Δa` is the update of the unknowns from
 the previous iteration. Note that `iter=1` implies `Δa=0`
 
 The advanced API alternative is [`check_convergence_criteria`](@ref)
-
 """
 function calculate_convergence_measure end
 
@@ -113,8 +114,7 @@ function calculate_convergence_measure end
     check_convergence_criteria(problem, nlsolver, Δa, iter) -> Bool
 
 Check if `problem` has converged and update the state 
-of `nlsolver` wrt. number of iterations and a convergence
-measure if applicable.
+of `nlsolver`, see [`FESolvers.update_state!`](@ref).
 """
 function check_convergence_criteria(problem, nlsolver, Δa, iter)
     r = calculate_convergence_measure(problem, Δa, iter)
@@ -124,16 +124,14 @@ end
 
 """
     postprocess!(problem, step, solver)
-    postprocess!(problem, step)
 
 Perform any postprocessing at the current time and step nr `step`
 Called at the beginning of the simulation, 
 and after time step converged right before `handle_converged!`.
-One can choose which version to overload, i.e. if the solver should be 
-given or not. 
 """
 function postprocess! end
-postprocess!(problem, step, solver) = postprocess!(problem, step)
+# The 2-argument (problem, step) version should be removed. Leave undocumented for now
+postprocess!(problem, step, solver) = postprocess!(problem, step) 
 postprocess!(args...) = nothing
 
 """

--- a/src/problem.jl
+++ b/src/problem.jl
@@ -85,6 +85,7 @@ this can be ignored and a simple function definition would be
 FESolvers.update_problem!(problem, Δx, _)
 ```
 
+
     update_problem!(problem, Δx; update_residual::Bool, update_jacobian::Bool)
 
 The old but now deprecated interface is still available without `update_spec`.

--- a/src/problem.jl
+++ b/src/problem.jl
@@ -65,8 +65,15 @@ time than the previous time if the solution did not converge.
 function update_to_next_step! end
 
 """
-    update_problem!(problem, Δx; update_residual::Bool, update_jacobian::Bool)
+    update_problem!(problem, Δx, update_spec::UpdateSpec)
 
+The `update_spec` gives the information about what and how to update.
+See the documentation for [`UpdateSpec`](@ref) for further details. 
+A simplified interface is called by default to perserve backwards compatibility,
+but it is recommended to use the new interface. 
+
+    update_problem!(problem, Δx; update_residual::Bool, update_jacobian::Bool)
+    
 Update the unknowns, `x += Δx`, if `!isnothing(Δx)`, and in any case
 * Assemble the residual if `update_residual=true`
 * Assemble the jacobian if `update_jacobian=true`
@@ -111,7 +118,7 @@ measure if applicable.
 """
 function check_convergence_criteria(problem, nlsolver, Δa, iter)
     r = calculate_convergence_measure(problem, Δa, iter)
-    update_state!(nlsolver, r)
+    update_state!(nlsolver, problem, r)
     return r < gettolerance(nlsolver)
 end
 

--- a/test/TestNLSolver.jl
+++ b/test/TestNLSolver.jl
@@ -3,12 +3,29 @@ Base.@kwdef struct TestNLSolver{LineSearch,T}
     ls::LineSearch
     maxiter::Int
     tolerance::T
+    numiter::Vector{Int}=[0]
+    residuals::Vector{T}=zeros(typeof(tolerance), maxiter)
 end
 FESolvers.getmaxiter(s::TestNLSolver) = s.maxiter
 FESolvers.gettolerance(s::TestNLSolver) = s.tolerance
+FESolvers.getnumiter(s::TestNLSolver) = s.numiter[1]
+FESolvers.get_convergence_measures(s::TestNLSolver, i=1:s.numiter[1]) = s.residuals[i]
+FESolvers.get_initial_update_spec(::TestNLSolver) = FESolvers.UpdateSpec(;jacobian=false, residual=false)
 
-function FESolvers.calculate_update!(Δa, problem, nlsolver::TestNLSolver, iter)
+function FESolvers.update_state!(s::TestNLSolver, problem, r)
+    s.numiter .+= 1
+    s.residuals[FESolvers.getnumiter(s)] = r
+end
+function FESolvers.reset_state!(s::TestNLSolver)
+    s.numiter .= 0
+end
+FESolvers.get_first_update_spec(::TestNLSolver, _) = FESolvers.UpdateSpec(;jacobian=true, residual=true)
+FESolvers.get_update_spec(::TestNLSolver) = FESolvers.UpdateSpec(;jacobian=true, residual=true)
+
+function FESolvers.calculate_update!(Δa, problem, nlsolver::TestNLSolver)
     Δa .= -FESolvers.getjacobian(problem)\FESolvers.getresidual(problem)
-    iter == 1 && FESolvers.linesearch!(Δa, problem, nlsolver.ls)
+    if FESolvers.getnumiter(nlsolver) == 1 
+        FESolvers.linesearch!(Δa, problem, nlsolver.ls)
+    end
     return Δa
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -64,3 +64,4 @@ include("test_timesteppers.jl")
     @test p_linear.uend ≈ uend
     @test length(p_linear.conv) == length(timehist)-1
 end
+# =#

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using FESolvers
 using Test
+import Base: @kwdef
 
 include("testproblem.jl")
 include("TestNLSolver.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -69,10 +69,10 @@ include("test_timesteppers.jl")
     lps = s_linear.nlsolver
     @test FESolvers.getnumiter(lps) == 0
     @test FESolvers.getmaxiter(lps) == 1
-    @test isnan(gettolerance(lps))
-    @test isnan(get_convergence_measures(lps, 1))
-    @test all(isnan, get_convergence_measures(lps))
-    @test all(isnan, get_convergence_measures(lps, 1:2))
-    @test_throws BoundsError get_convergence_measures(lps, 1:3)
+    @test isnan(FESolvers.gettolerance(lps))
+    @test isnan(FESolvers.get_convergence_measures(lps, 1))
+    @test all(isnan, FESolvers.get_convergence_measures(lps))
+    @test all(isnan, FESolvers.get_convergence_measures(lps, 1:2))
+    @test_throws BoundsError FESolvers.get_convergence_measures(lps, 1:3)
 end
 # =#

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -64,5 +64,15 @@ include("test_timesteppers.jl")
     @test last(p_linear.u) ≈ last(p_linear.uend)
     @test p_linear.uend ≈ uend
     @test length(p_linear.conv) == length(timehist)-1
+
+    # Smoke-test the access function for the linear nlsolver
+    lps = s_linear.nlsolver
+    @test FESolvers.getnumiter(lps) == 0
+    @test FESolvers.getmaxiter(lps) == 1
+    @test isnan(gettolerance(lps))
+    @test isnan(get_convergence_measures(lps, 1))
+    @test all(isnan, get_convergence_measures(lps))
+    @test all(isnan, get_convergence_measures(lps, 1:2))
+    @test_throws BoundsError get_convergence_measures(lps, 1:3)
 end
 # =#

--- a/test/test_nlsolvers.jl
+++ b/test/test_nlsolvers.jl
@@ -1,19 +1,44 @@
 @testset "nlsolvers" begin
+    function test_basic_functions(nlsolver, tol, maxiter)
+        @test FESolvers.gettolerance(nlsolver) ≈ tol
+        @test FESolvers.getmaxiter(nlsolver) == maxiter
+    end
     tol = 1.e-6
-    ls = ArmijoGoldstein(μ=1e-4, β=0.5, τ0=1.0)
-    steepestdescent= SteepestDescent(;maxiter=30000, tolerance=1e-3, linesearch=ls)
-    newton_ls = NewtonSolver(;maxiter=30, tolerance=tol, linesearch=ls)
-    newton = NewtonSolver(;maxiter=30, tolerance=tol)
+    maxiter = 30
+    ls = ArmijoGoldstein(μ=1e-3, β=0.5, τ0=1.0)
+    steepestdescent_tol = 1e-4
+    steepestdescent = SteepestDescent(;maxiter=maxiter, tolerance=steepestdescent_tol, linesearch=ls)
+    test_basic_functions(steepestdescent, steepestdescent_tol, maxiter)
+    newton_ls = NewtonSolver(;maxiter=maxiter, tolerance=tol, linesearch=ls)
+    newton = NewtonSolver(;maxiter=maxiter, tolerance=tol)
+    test_basic_functions(newton, tol, maxiter)
     newton_nofirst = NewtonSolver(;maxiter=30, tolerance=tol, update_jac_first=false)
-    custom = TestNLSolver(;maxiter=30, tolerance=tol, ls=ls)
-    for nlsolver in [steepestdescent, newton_ls, newton, custom, newton_nofirst]
-        problem = Rosenbrock() 
-        nlsolver === newton_nofirst && FESolvers.update_problem!(problem, nothing; update_jacobian=true)
+    custom = TestNLSolver(;maxiter=maxiter, tolerance=tol, ls=ls)
+    adaptive = FESolvers.AdaptiveNewtonSolver(;maxiter=maxiter, tolerance=tol, 
+        update_types=(:steepestdescent, :true),
+        linesearch=ls,
+        switch_criterion=FESolvers.NumIterSwitch(3)
+        )
+    for nlsolver in [steepestdescent, newton_ls, newton, custom, newton_nofirst, adaptive]
+        if nlsolver===steepestdescent
+            problem = Rosenbrock(;a=0.1, b=0.2) # Make it easy enough for pure linesearch
+        else
+            problem = Rosenbrock(;a=0.2, b=1.0) # A bit harder, but still quite easy
+        end
+        if FESolvers.do_initial_update(nlsolver) 
+            FESolvers.update_problem!(problem, nothing, FESolvers.get_initial_update_spec(nlsolver))
+        end
         converged = FESolvers.solve_nonlinear!(problem, nlsolver, true)
         @test converged
-        @test isapprox(norm(problem.r), 0.0; atol=1e-2)
-        @test all(isapprox.(problem.x, 1.0; atol=1e-5))
+        @test FESolvers.getnumiter(nlsolver) > 3 # Test makes sense; some iterations required
+        @test isapprox(norm(problem.r), 0.0; atol=FESolvers.gettolerance(nlsolver))
+        @test isapprox(problem.x[1], problem.a; atol=1e-2) # Just to ensure test is sound
+        @test isapprox(problem.x[2], problem.a^2; atol=1e-2)
     end
+    # Sanity check that the AdaptiveNewtonSolver needs more iterations since it starts by a few 
+    # steepest descent iterations
+    @test FESolvers.getnumiter(adaptive) > FESolvers.getnumiter(newton)
+
     # Test that it runs properly when it doesn't converge 
     newton = NewtonSolver(;tolerance=-1.0)
     converged = FESolvers.solve_nonlinear!(Rosenbrock(), newton, true)
@@ -23,4 +48,74 @@
     #@test !converged # Without updating problem, matrix should be all zero (for now, just throws)
     converged = FESolvers.solve_nonlinear!(Rosenbrock(), newton_nofirst, #=last_converged=#false)
     @test converged # If did not converge in last step, should calculate jacobian again
+end
+
+@testset "AdaptiveNewtonSolver switches" begin
+    makesolver(switch) = FESolvers.AdaptiveNewtonSolver(;
+        update_types=[1, 2],
+        switch_criterion=switch,
+        maxiter=10
+        )
+    function test_expected!(nls; expected_reset, expected_nr)
+        reset, nr = FESolvers.switch_information(nls.switch_criterion, nls)
+        @test reset == expected_reset
+        @test nr == expected_nr
+        # Make the updates that should be made
+        nls.update_type_nr = expected_nr
+        nls.reset_problem = expected_reset
+    end
+
+    @testset "NumIterSwitch" begin
+        nls = makesolver(FESolvers.NumIterSwitch(4))
+        test_expected!(nls, expected_reset=false, expected_nr=1)
+        nls.numiter = 5
+        test_expected!(nls, expected_reset=false, expected_nr=2)
+    end
+    @testset "ToleranceSwitch" begin
+        nls = makesolver(FESolvers.ToleranceSwitch(2.0))
+        
+        nls.numiter = 1
+        nls.residuals[1] = 3.0 # Should use first method
+        test_expected!(nls; expected_reset=false, expected_nr=1)
+
+        nls.numiter = 2
+        nls.residuals[2] = 1.0 # Should use second method
+        test_expected!(nls; expected_reset=false, expected_nr=2)
+
+        nls.numiter = 3
+        nls.residuals[3] = 3.0 # Should use first method again, and reset
+        test_expected!(nls; expected_reset=true, expected_nr=1)
+    end
+    @testset "IncreaseSwitch" begin
+        nls = makesolver(FESolvers.IncreaseSwitch(num_slow=2))
+
+        nls.numiter = 2
+        nls.residuals[1] = 9.0
+        nls.residuals[2] = 8.0 # Decreasing
+        test_expected!(nls; expected_reset=false, expected_nr=1)
+        
+        nls.numiter = 3
+        nls.residuals[3] = 9.0 # Increasing
+        test_expected!(nls; expected_reset=true, expected_nr=2)
+        
+        nls.numiter = 4
+        nls.residuals[4] = 10.0 # Still increasing 
+        test_expected!(nls; expected_reset=false, expected_nr=2)
+        
+        nls.numiter = 5
+        nls.residuals[5] = 9.0 # Decreasing 1 time
+        test_expected!(nls; expected_reset=false, expected_nr=2)
+
+        nls.numiter = 6
+        nls.residuals[6] = 8.8 # Decreasing 2 times
+        test_expected!(nls; expected_reset=false, expected_nr=2)
+
+        nls.numiter = 7
+        nls.residuals[7] = 8.4 # Decreasing 3 times > num_slow
+        test_expected!(nls; expected_reset=false, expected_nr=1)
+
+        nls.numiter = 8
+        nls.residuals[8] = 9.0 # Increasing again
+        test_expected!(nls; expected_reset=true, expected_nr=2)
+    end
 end

--- a/test/test_timesteppers.jl
+++ b/test/test_timesteppers.jl
@@ -77,6 +77,14 @@ FESolvers.getmaxiter(::Nothing) = 4
         # Last two steps should take half each when the reminder is less then Δt_min
         @test Δth[end] ≈ Δth[end-1] ≈ (mod(t_end, Δt) + Δt)/2
         @test all(Δth[1:end-2] .≈ 0.1)
+
+        # Test errors
+        Δt = 0.1
+        ts = AdaptiveTimeStepper(Δt, 3*Δt; Δt_min=Δt)
+        # Not converged in first iteration (setup issue)
+        @test_throws ArgumentError FESolvers.update_time(ts, nothing, 0.0, #=step=# 1, #=converged=# false)
+        # Cannot reduce time step further
+        @test_throws FESolvers.ConvergenceError FESolvers.update_time(ts, nothing, Δt, 2, false)
     end
 
 end

--- a/test/testproblem.jl
+++ b/test/testproblem.jl
@@ -44,7 +44,7 @@ function FESolvers.update_to_next_step!(p::TestProblem, time)
     p.time[1] = time
 end
 
-function FESolvers.update_problem!(p::TestProblem, Δx; kwargs...)
+function FESolvers.update_problem!(p::TestProblem, Δx, _)
     isnothing(Δx) || (p.x .+= Δx)
     p.r .= residual(p.x, p.f)
     p.drdx .= ForwardDiff.jacobian(x_->residual(x_, p.f), p.x)
@@ -89,10 +89,10 @@ function FESolvers.update_to_next_step!(p::LinearTestProblem, time)
     p.r[end]=-p.forcefun(time)
     p.u[1] = p.dbcfun(time)
 end
-function FESolvers.update_problem!(p::LinearTestProblem, Δu; update_jacobian, update_residual)
+function FESolvers.update_problem!(p::LinearTestProblem, Δu, update_spec)
     isnothing(Δu) || (p.u .+= Δu)
-    update_residual && (p.r .+= p.K0*p.u; p.r[1]=0)
-    if update_jacobian
+    FESolvers.should_update_residual(update_spec) && (p.r .+= p.K0*p.u; p.r[1]=0)
+    if FESolvers.should_update_jacobian(update_spec)
         p.K .= p.K0
         # "apply_zero!"
         p.K[:,1] .= 0; p.K[1,:] .= 0; p.K[1,1] = p.K0[1,1]


### PR DESCRIPTION
The `AdaptiveNewtonSolver` supports an experimental feature to switch between different update strategies. 
This PR goes in the direction that we should not ask the user for different system_matrices via the `get_system_matrix`, but rather tell the user problem which matrix to update in `update_problem!` (and expect that this matrix would be returned later). 

Specifically, the struct `UpdateSpec` and associated query methods are introduced. 
The `Rosenbrock` test case is updated and tested with `AdaptiveNewtonSolver`. 